### PR TITLE
feat: add pre-commit hook for automatic lint-fix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,5 @@
 # Example : `git commit --no-verify`
 #
 
-pnpm exec nano-staged \
-  --config './.nano-staged.mjs' \
-  --allow-empty
+# run lint-fix on all staged files and update the staged files with fixes
+pnpm lint-fix && git add -u $(git diff --cached --name-only --diff-filter=ACMRT)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# script implements the precommit hook for automatic linting on "git commit"
+#
+# this script is used to build all packages of the monorepo
+#
+
+pnpm exec nano-staged \
+  --config './.nano-staged.mjs' \
+  --allow-empty

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 #
-# script implements the precommit hook for automatic linting on "git commit"
+# script implements the precommit hook for automatic lint-fix staged files on "git commit"
 #
-# this script is used to build all packages of the monorepo
+# this script is executed by the pre-commit hook in .git/hooks and will automatically lin-fix all staged files
+# any fixes will be automatically be included in the commit
+#
+# If you want to disable git hooks for some reason you can disable the git hooks by adding `--no-verify` to the git command.
+# Example : `git commit --no-verify`
 #
 
 pnpm exec nano-staged \

--- a/.nano-staged.mjs
+++ b/.nano-staged.mjs
@@ -1,0 +1,7 @@
+/*
+  default nano-staged configuration
+*/
+
+export default {
+  '*': 'pnpm lint-fix',
+};

--- a/.nano-staged.mjs
+++ b/.nano-staged.mjs
@@ -1,7 +1,0 @@
-/*
-  default nano-staged configuration
-*/
-
-export default {
-  '*': 'pnpm lint-fix',
-};

--- a/README.md
+++ b/README.md
@@ -343,7 +343,17 @@ Using `changeset` to create a release
 
 ### Git
 
-@TODO: Git Flow vs Git-Flow vs Trunk based development. we need a decision here.
+The project used git hooks at various stages.
+
+For example the `pre-commit` hook will automatically lint-fix the code before committing and will abort the commit process if lint-fix was not successful.
+
+Git hooks are located in the `./.githooks` directory.
+
+The hooks are automatically installed by the `pnpm install` command.
+
+> [!TIP]
+> If you want to disable git hooks for some reason you can disable the git hooks by adding `--no-verify` to the git command.
+> Example : `git commit --no-verify`
 
 #### Workflows
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Using `changeset` to create a release
 
 ### Git
 
-The project used git hooks at various stages.
+The project uses git hooks at various stages.
 
 For example the `pre-commit` hook will automatically lint-fix the code before committing and will abort the commit process if lint-fix was not successful.
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "eslint-plugin-storybook": "^0.11.2",
     "git-cz": "4.9.0",
     "globals": "15.14.0",
-    "nano-staged": "0.8.0",
     "prettier": "3.4.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "./scripts/test.sh",
     "gh-cli": "./scripts/gh-cli.sh",
     "go-waas": "./scripts/go-waas.sh",
-    "playground": "./scripts/playground.sh"
+    "playground": "./scripts/playground.sh",
+    "prepare": "./scripts/_prepare.sh"
   },
   "keywords": [
     "pnpm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,6 @@ importers:
       globals:
         specifier: 15.14.0
         version: 15.14.0
-      nano-staged:
-        specifier: 0.8.0
-        version: 0.8.0
       prettier:
         specifier: 3.4.2
         version: 3.4.2
@@ -6308,11 +6305,6 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  nano-staged@0.8.0:
-    resolution: {integrity: sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
 
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -16376,10 +16368,6 @@ snapshots:
   mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
-
-  nano-staged@0.8.0:
-    dependencies:
-      picocolors: 1.1.1
 
   nanoid@3.3.8: {}
 

--- a/scripts/_prepare.sh
+++ b/scripts/_prepare.sh
@@ -15,6 +15,7 @@ if [[ "${CI:-}" == "true" ]]; then
   exit 0
 fi
 
-
+# If you want to disable git hooks for some reason you can disable the git hooks by adding `--no-verify` to the git command.
+# Example : `git commit --no-verify`
 ionos.wordpress.log_info "Setting up git hooks"
 git config core.hookspath "./.githooks"

--- a/scripts/_prepare.sh
+++ b/scripts/_prepare.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# script installs the git hooks for linting on pre commit
+#
+# this script is used to build all packages of the monorepo
+#
+
+# bootstrap the environment
+source "$(realpath $0 | xargs dirname)/includes/bootstrap.sh"
+
+# execute only when NOT in CI environment
+if [[ "${CI:-}" == "true" ]]; then
+  ionos.wordpress.log_warn "CI environment detected - skip setting up git hooks"
+  exit 0
+fi
+
+
+ionos.wordpress.log_info "Setting up git hooks"
+git config core.hookspath "./.githooks"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -89,7 +89,8 @@ git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 # commit changes
-git commit -am "chore(release) : updated versions [skip release]"
+# no-verify will disable the pre-commit hook since we wont automatically run lint-fix
+git commit --no-verify -am "chore(release) : updated versions [skip release]"
 
 # tag release
 pnpm changeset tag


### PR DESCRIPTION
this feature adds automatic lint-fix execution on all staged files during `git commit`.

It will only operate on staged files.

Eventually fixed files will automatically be part of the commit.

You can disable this behavior by adding `--no-verify` to the git command. 

Example: 

- `git commit` will automatically execute lint-fix 
- `git commit --no-verify` will disable automatically execution of lint-fix 

This feature is automatically installed on `pnpm install`