### PR TITLE
Fix/wp env eacces

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,12 @@
 # bootstrap the environment
 source "$(realpath $0 | xargs dirname)/includes/bootstrap.sh"
 
+# skip building if BUILD_UP_TO_DATE is set to 1
+if [[ "${BUILD_UP_TO_DATE:-}" == '1' ]]; then
+  ionos.wordpress.log_warn "skip (re)building : BUILD_UP_TO_DATE=1"
+  exit 0
+fi
+
 # MARK: parse arguments
 FORCE=no
 VERBOSE=no
@@ -58,13 +64,6 @@ FILTER="${FILTER[@]/#/--filter=}"
 # invoke all build steps by default
 [[ ${#USE[@]} -eq 0 ]] && USE=("all")
 # ENDMARK:
-
-
-# skip building if BUILD_UP_TO_DATE is set to 1
-if [[ "${BUILD_UP_TO_DATE:-}" == '1' ]]; then
-  ionos.wordpress.log_warn "skip (re)building : BUILD_UP_TO_DATE=1"
-  exit 0
-fi
 
 # quirks : when switch between devcontainer and local development
 # the node dependencies are not identical for some reason. thats why we need to ensure

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -9,5 +9,4 @@
 # bootstrap the environment
 source "$(realpath $0 | xargs dirname)/includes/bootstrap.sh"
 
-echo 'y' | pnpm exec wp-env destroy --debug
-
+echo 'y' | pnpm exec wp-env destroy || rm -rf "$WP_ENV_HOME"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -88,18 +88,20 @@ pnpm build
 EOF
 )
 
+# wp-env workaround: if wp-env was not able to start successfully
+# it might happen that some mapped files within wp-env-home do not have the correct permissons
+# and as a result a floolow up pnpm start will fail with EACCES : permission denied
+# we can workaround that by deleting the mapped files and let wp-env recreate them
 (
-  # wp-env workaround: if wp-env was not able to start successfully
-  # it might happen that some mapped files within wp-env-home do not have the correct permissons
-  # and as a result a floolow up pnpm start will fail with EACCES : permission denied
-  # we can workaround that by deleting the mapped files and let wp-env recreate them
   WPENV_INSTALLPATH="$(realpath --relative-to $(pwd) $(pnpm exec wp-env install-path))"
   # if at least a single WordPress installation exists in WP_ENV_HOME wp-env is not fully up and running
   if [[ -d "$WPENV_INSTALLPATH/WordPress" ]] && [[ "$(docker ps -q --filter "name=$(basename $WPENV_INSTALLPATH)" | wc -l)" -lt '6' ]]; then
     # for each wordpress installation in wp-env
     for WORDPRESS_INSTALLATION in $(find $WPENV_INSTALLPATH -maxdepth 1 -mindepth 1 -type d -name "*WordPress*") ; do
       # remove all files and directories that are not owned by the current user
-      find "$WORDPRESS_INSTALLATION" ! -user "$(whoami)" -exec rm -rf {} &>/dev/null \;
+      for FILE_TO_FIX in $(find "$WORDPRESS_INSTALLATION" ! -user "$(whoami)"); do
+        [[ -e "$FILE_TO_FIX" ]] && rm -rf "$FILE_TO_FIX"
+      done
     done
   fi
 )

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -203,21 +203,21 @@ for prefix in '' 'tests-' ; do
   pnpm exec wp-env run ${prefix}cli wp --quiet rewrite flush
 
   # Updates an option value for example the value of Simple page is id = 2
-  pnpm exec wp-env run ${prefix}cli wp option update page_on_front 2
+  pnpm exec wp-env run ${prefix}cli wp --quiet option update page_on_front 2
   # Update the page as front page by default.
-  pnpm exec wp-env run ${prefix}cli wp option update show_on_front page
+  pnpm exec wp-env run ${prefix}cli wp --quiet option update show_on_front page
 
   # activate twentytwenty-five theme in all wp-env instances (test and development)
-  pnpm exec wp-env run ${prefix}cli wp theme activate twentytwentyfive
+  pnpm exec wp-env run ${prefix}cli wp --quiet theme activate twentytwentyfive
 
   # activate all installed plugins in all wp-env instances (test and development)
-  pnpm exec wp-env run ${prefix}cli wp plugin activate --all
+  pnpm exec wp-env run ${prefix}cli wp --quiet plugin activate --all
 
   # emulate ionos brand by default
-  pnpm exec wp-env run ${prefix}cli wp option update ionos_group_brand ionos
+  pnpm exec wp-env run ${prefix}cli wp --quiet option update ionos_group_brand ionos
 
   # fix permissions for mu-plugins folder if any
-  # (leaving the permisions as-is will rsult in an error on destroy restart wp-env)
+  # (leaving the permisions as-is will result in an error on destroy restart wp-env)
   if find packages/wp-mu-plugin -mindepth 1 -maxdepth 1 -type d -printf '%f\n' &>/dev/null; then
     pnpm exec wp-env run ${prefix}cli sh -c 'sudo chmod a+w -R /var/www/html/wp-content/mu-plugins' 2>/dev/null || true
   fi


### PR DESCRIPTION
fixes wp-env starts (aka "pnpm start") after failed wp-env starts (for example during download timeouts because of slow vpn connections).

