### PR TITLE
feat: add GitHub Container Registry login step and enable devcontaine…

### DIFF
--- a/.github/shared/actions/devcontainer-shell-run/action.yaml
+++ b/.github/shared/actions/devcontainer-shell-run/action.yaml
@@ -14,6 +14,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - uses: './.github/shared/actions/devcontainer-image-name'
       id: image_name
 

--- a/.github/workflows/build-devcontainer-image.yaml
+++ b/.github/workflows/build-devcontainer-image.yaml
@@ -46,10 +46,10 @@ jobs:
       - name: Build dev container and push to GitHub Container Registry
         uses: devcontainers/ci@v0.3
         with:
-          # push image only if the branch is main and the event is push
-          refFilterForPush: |
-            refs/heads/main
-            refs/heads/develop
+          # # push image only if the branch is main and the event is push
+          # refFilterForPush: |
+          #   refs/heads/main
+          #   refs/heads/develop
           eventFilterForPush: push
           imageName: ${{ steps.image_name.outputs.image_name }}
           runCmd: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,14 +27,14 @@ permissions:
   id-token: write
 
 jobs:
-  # build_devcontainer_image:
-  #   uses: ./.github/workflows/build-devcontainer-image.yaml
-  #   secrets: inherit
+  build_devcontainer_image:
+    uses: ./.github/workflows/build-devcontainer-image.yaml
+    secrets: inherit
 
   test:
     runs-on: ubuntu-latest
-    # needs:
-    #   - build_devcontainer_image
+    needs:
+      - build_devcontainer_image
     steps:
       - name: checkout branch from git
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,14 +24,14 @@ permissions:
   id-token: write
 
 jobs:
-  # build_devcontainer_image:
-  #   uses: ./.github/workflows/build-devcontainer-image.yaml
-  #   secrets: inherit
+  build_devcontainer_image:
+    uses: ./.github/workflows/build-devcontainer-image.yaml
+    secrets: inherit
 
   release:
     runs-on: ubuntu-latest
-    # needs:
-    #   - build_devcontainer_image
+    needs:
+      - build_devcontainer_image
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     if: "!contains(github.event.head_commit.message, 'skip release')"


### PR DESCRIPTION
- reenabled separate actions for image builds in workflows

- use built images from cache in workflows

- use alternate base image for jobs to speed up github actions - https://docs.blacksmith.sh/introduction/quickstart 