### PR TITLE
chore: add xdebug.php-debug extension to VSCode configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
     "johnbillion.vscode-wordpress-hooks",
     "bmewburn.vscode-intelephense-client",
     "ms-playwright.playwright",
-    "Gruntfuggly.todo-tree"
+    "Gruntfuggly.todo-tree",
+    "xdebug.php-debug"
   ]
 }


### PR DESCRIPTION
add missing xdebug extension to vscode recommended extensions