### PR TITLE
fix: validate single chromium installation for Playwright environment setup

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -59,6 +59,13 @@ done
 [[ ${#USE[@]} -eq 0 ]] && USE=("all")
 
 function ionos.wordpress.prepare_playwright_environment() {
+  # Check if the find command returns exactly the one chromium installation we expect
+  if [[ "$(find ~/.cache/ms-playwright -path "*/chrome-linux/chrome" 2>/dev/null | wc -l)" -ne 1 ]]; then
+    ionos.wordpress.log_warn "Multiple or no Playwright chromium paths found (check 'find ~/.cache/ms-playwright -path "*/chrome-linux/chrome"')."
+    ionos.wordpress.log_warn "Please install it manually by running 'PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=10000 pnpx playwright install --with-deps chromium'"
+    exit 1;
+  fi
+
     # used to prevent wp-scripts test-playwright command from downloading browsers
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
   # we need to inject the path to the installed chrome binary


### PR DESCRIPTION
# local usage

if e2e test suite doesn't find the right playwright chromium path it expects 

the test script will output instructions how to fix this issue