### PR TITLE
Refactor/build behaviour

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,3 +25,6 @@
 
 # used for docker image metadata generation
 # VENDOR='IONOS Group'
+
+# set BUILD_UP_TO_DATE=1 will disable automatic (re)building the sources on start / test
+# BUILD_UP_TO_DATE=1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,12 +9,6 @@
 # bootstrap the environment
 source "$(realpath $0 | xargs dirname)/includes/bootstrap.sh"
 
-# skip building if BUILD_UP_TO_DATE is set to 1
-if [[ "${BUILD_UP_TO_DATE:-}" == '1' ]]; then
-  ionos.wordpress.log_warn "skip (re)building : BUILD_UP_TO_DATE=1"
-  exit 0
-fi
-
 # MARK: parse arguments
 FORCE=no
 VERBOSE=no

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,7 +10,12 @@
 source "$(realpath $0 | xargs dirname)/includes/bootstrap.sh"
 
 # (re)build the project
-pnpm build
+if [[ "${BUILD_UP_TO_DATE:-}" == '1' ]]; then
+  # skip building if BUILD_UP_TO_DATE is set to 1
+  ionos.wordpress.log_warn "skip (re)building : BUILD_UP_TO_DATE=1 detected"
+else
+  pnpm build
+fi
 
 # generate .wp-env.json
 (


### PR DESCRIPTION
This pull request refactors the use of the BUILD_UP_TO_DATE :  

If you don't want all plugins to be built at every possible and impossible opportunity (e.g. for “pnpm start” and “pnpm test”), write the following in your `.env.local` (template for this is in the repo) 

```
BUILD_UP_TO_DATE=1
```

Then you are responsible for rebuilding at the right moment.