### PR TITLE
Fix php linting

### DIFF
--- a/packages/docker/ecs-php/ecs-config.php
+++ b/packages/docker/ecs-php/ecs-config.php
@@ -3,6 +3,7 @@
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
+use WordPressCS\WordPress\Sniffs\WP\GlobalVariablesOverrideSniff;
 
 $codeSnifferConfig = new PHP_CodeSniffer\Config(["--standard=./packages/docker/ecs-php/ruleset.xml"]);
 PHP_CodeSniffer\Autoload::addSearchPath('/composer/vendor/wp-coding-standards/wpcs/WordPress', "WordPressCS\WordPress");
@@ -62,5 +63,8 @@ return $configure->withRules([
   // align assoc arrays
   ->withConfiguredRule(BinaryOperatorSpacesFixer::class, [
     'default' => 'align',
+  ])
+  ->withConfiguredRule(GlobalVariablesOverrideSniff::class, [
+    'treat_files_as_scoped' => true,
   ])
 ;

--- a/packages/docker/ecs-php/package.json
+++ b/packages/docker/ecs-php/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ionos-wordpress/ecs-php",
   "description": "Docker image providing the most recent PHP easy-coding-standard in a docker image",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "keywords": [
     "php",


### PR DESCRIPTION
fixes linting by 

- excluding `wp_die`, `printf` and `error_log` from WordPress Coding standard rule WordPressCS\WordPress\Sniffs\Security\EscapeOutputSniff

- configuring WordPressCS\WordPress\Sniffs\WP\GlobalVariablesOverrideSniff to `treat_files_as_scoped` = true
 