### PR TITLE
fix: add README.md to .distignore to prevent it from being included in the essentials plugin archive

### DIFF
--- a/packages/wp-plugin/essentials/.distignore
+++ b/packages/wp-plugin/essentials/.distignore
@@ -3,3 +3,4 @@
 inc/dashboard/editor.php
 inc/dashboard/block-template.php
 inc/dashboard/global-styles.json
+inc/dashboard/README.md


### PR DESCRIPTION
the README.md in dashboard feature folder should not be distributed in the plugin archive.

This PR adds the file to the `.distignore` file of the essentials plugin