### PR TITLE
feat: add pull request template to standardize submission process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+<!--
+     For Work In Progress Pull Requests, please use the Draft PR feature,
+     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+
+     For a timely review/response, please avoid force-pushing additional
+     commits if your PR already received reviews or comments.
+
+     Before submitting a Pull Request, please ensure you've done the following:
+
+     - Create small PRs. In most cases this will be possible.
+     - Provide tests for your changes.
+     - Use commitizen standard conformant commit messages.
+     - Update any related documentation and include any relevant screenshots.
+-->
+
+## What type of PR is this? (check all applicable)
+
+- [ ] Refactor
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Optimization
+- [ ] Documentation Update
+
+## Description
+
+## Related Tickets & Documents
+
+- Related Issue #
+- Closes #
+
+## PR Tasks
+
+I have
+
+- [ ] linted the sources
+- [ ] updated/added tests for the changes if needed
+- [ ] runned successfully the tests locally
+- [ ] updated the documentation if nessessary
+
+## QA Instructions, Screenshots, Recordings
+
+_Please replace this line with instructions on how to test your changes, a note
+on the devices and browsers this has been tested on, as well as any relevant
+images for UI changes._
+
+_If the ui was changed by PR please provide a before and after screenshot_
+
+## [optional] Are there any post deployment tasks we need to perform?


### PR DESCRIPTION
the template contents will be automatically inserted into the description field of newly created pull requests and can be freely edited.

it helps 
- developers by providing a checklist of thing to be done when preparing code for the pull requests
- reviewers to get a clue what the pr does and what to test