### PR TITLE
integrate linter output with vscode problems panel and provide linter summary at end of lint/lint:fix output

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+*.js
+*.jsx
+*.scss
+*.css

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,6 +12,7 @@
     "bmewburn.vscode-intelephense-client",
     "ms-playwright.playwright",
     "Gruntfuggly.todo-tree",
-    "xdebug.php-debug"
+    "xdebug.php-debug",
+    "batyan-soft.fast-tasks"
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,326 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "problemMatcher": [],
+  "tasks": [
+    {
+      "label": "lint:php",
+      "detail": "Lint PHP",
+      "type": "shell",
+      "command": "pnpm -s lint:php",
+      "problemMatcher": [
+        {
+          "owner": "lint:php",
+          "applyTo": "allDocuments",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "source": "lint:php",
+          "pattern": [
+            /*
+    ------------------------------------------------------------------------
+    packages/wp-plugin/essentials/src/dashboard/blocks/vulnerability/render.php:52
+    ------------------------------------------------------------------------
+    Use Yoda Condition checks, you must.
+
+    Reported by:
+    "WordPressCS\WordPress\Sniffs\PHP\YodaConditionsSniff.NotYoda"
+    ------------------------------------------------------------------------
+            */
+            {
+              "regexp": "^(.*)$"
+            },
+            {
+              "regexp": "^(.+):(\\d+)$",
+              "file": 1,
+              "line": 2
+            },
+            {
+              "regexp": "^(.*)$"
+            },
+            {
+              "regexp": "^(.*)$",
+              "message": 1
+            }
+          ]
+        }
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint-fix:php",
+      "detail": "Lint fix PHP",
+      "type": "shell",
+      "command": "pnpm -s lint-fix:php ",
+      "problemMatcher": [
+        {
+          "owner": "lint:php",
+          "applyTo": "allDocuments",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "source": "lint:php",
+          "pattern": [
+            /*
+    ------------------------------------------------------------------------
+    packages/wp-plugin/essentials/src/dashboard/blocks/vulnerability/render.php:52
+    ------------------------------------------------------------------------
+    Use Yoda Condition checks, you must.
+
+    Reported by:
+    "WordPressCS\WordPress\Sniffs\PHP\YodaConditionsSniff.NotYoda"
+    ------------------------------------------------------------------------
+            */
+            {
+              "regexp": "^(.*)$"
+            },
+            {
+              "regexp": "^(.+):(\\d+)$",
+              "file": 1,
+              "line": 2
+            },
+            {
+              "regexp": "^(.*)$"
+            },
+            {
+              "regexp": "^(.*)$",
+              "message": 1
+            }
+          ]
+        }
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint:js",
+      "detail": "Lint Javascript",
+      "type": "shell",
+      "command": "pnpm -s lint:js",
+      "problemMatcher": ["$eslint-stylish"],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint-fix:js",
+      "detail": "Lint fix Javascript",
+      "type": "shell",
+      "command": "pnpm -s lint-fix:js",
+      "problemMatcher": ["$eslint-stylish"],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint:css",
+      "detail": "Lint CSS/SCSS",
+      "type": "shell",
+      "command": "pnpm -s lint:css",
+      "problemMatcher": [
+        {
+          "source": "lint:css",
+          "owner": "lint:css",
+          "fileLocation": "absolute",
+          "pattern": {
+            "regexp": "^(.+): line (\\d+), col (\\d+), (\\w+) - (.+)( \\((.+)\\))?$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "message": 5,
+            "code": 6
+          }
+        }
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint-fix:css",
+      "detail": "Lint fix CSS/SCSS",
+      "type": "shell",
+      "command": "pnpm -s lint-fix:css",
+      "problemMatcher": [
+        {
+          "source": "lint:css",
+          "owner": "lint:css",
+          "fileLocation": "absolute",
+          "pattern": {
+            "regexp": "^(.+): line (\\d+), col (\\d+), (\\w+) - (.+)( \\((.+)\\))?$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "message": 5,
+            "code": 6
+          }
+        }
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint:i18n",
+      "detail": "Lint i18n",
+      "type": "shell",
+      "command": "pnpm -s lint:i18n",
+      "problemMatcher": [
+        {
+          "source": "lint:i18n",
+          "owner": "lint:i18n",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "pattern": [
+            /*
+>>> Working on: ./packages/wp-plugin/essentials/languages/ionos-essentials-es_ES.po
+118:msgid "Add new page"
+211:msgid "Some other string"
+                */
+            {
+              "regexp": "^>>> Working on: (.+)$",
+              "file": 1
+            },
+            {
+              "regexp": "^(\\d+):msgid \"(.*)\"$",
+              "line": 1,
+              "message": 2
+            }
+          ]
+        }
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint-fix:i18n",
+      "detail": "Lint fix i18n",
+      "type": "shell",
+      "command": "pnpm -s lint-fix:i18n",
+      "problemMatcher": [
+        {
+          "source": "lint:i18n",
+          "owner": "lint:i18n",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "pattern": [
+            /*
+>>> Working on: ./packages/wp-plugin/essentials/languages/ionos-essentials-es_ES.po
+118:msgid "Add new page"
+211:msgid "Some other string"
+                */
+            {
+              "regexp": "^>>> Working on: (.+)$",
+              "file": 1
+            },
+            {
+              "regexp": "^(\\d+):msgid \"(.*)\"$",
+              "line": 1,
+              "message": 2
+            }
+          ]
+        }
+      ],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint",
+      "detail": "Lint",
+      "type": "shell",
+      "command": "pnpm -s lint --use pnpm --use wp",
+      "problemMatcher": [
+        /*#
+ionos.wordpress.pnpm:257 : pnpm-lock.yaml:1 : pnpm-lock.yaml outdated - please update it using 'pnpm install'
+ionos.wordpress.wordpress_plugin:293 : ./packages/wp-plugin/essentials/essentials.php:1 : plugin header 'Description' is missing or empty
+        */
+        {
+          "source": "lint:pnpm+wp",
+          "owner": "lint:pnpm+wp",
+          "applyTo": "allDocuments",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "pattern": {
+            "regexp": "^[^ ]+ : (.+):(\\d+) : (.*)$",
+            "file": 1,
+            "line": 2,
+            "message": 3
+          }
+        }
+      ],
+      "dependsOn": ["lint:php", "lint:js", "lint:css", "lint:i18n"],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    },
+    {
+      "label": "lint:fix",
+      "detail": "Lint fix",
+      "type": "shell",
+      "command": "pnpm -s lint-fix --use pnpm --use wp",
+      "problemMatcher": [
+        /*#
+ionos.wordpress.pnpm:257 : pnpm-lock.yaml:1 : pnpm-lock.yaml outdated - please update it using 'pnpm install'
+ionos.wordpress.wordpress_plugin:293 : ./packages/wp-plugin/essentials/essentials.php:1 : plugin header 'Description' is missing or empty
+        */
+        {
+          "source": "lint:pnpm+wp",
+          "owner": "lint:pnpm+wp",
+          "applyTo": "allDocuments",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "pattern": {
+            "regexp": "^[^ ]+ : (.+):(\\d+) : (.*)$",
+            "file": 1,
+            "line": 2,
+            "message": 3
+          }
+        }
+      ],
+      "dependsOn": ["lint-fix:php", "lint-fix:js", "lint-fix:css", "lint-fix:i18n"],
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "clear": true,
+        "showReuseMessage": false,
+        "revealProblems": "onProblem"
+      }
+    }
+  ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,6 +77,7 @@ export default [
             '@wordpress/hooks',
             '@wordpress/block-editor',
             '@wordpress/blocks',
+            '@wordpress/api-fetch',
             '@wordpress/server-side-render',
             '@wordpress/e2e-test-utils-playwright',
             '@playwright/test',

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -50,7 +50,7 @@ function ionos.wordpress.prettier() {
   ionos.wordpress.log_header "$([[ "$FIX" == 'yes' ]] && echo -n "lint-fix" || echo -n "lint") html/yml/md/etc. files with prettier ..."
 
   # prettier
-  pnpm exec prettier --config ./.prettierrc.js --ignore-path ./.gitignore --ignore-path ./.lintignore --check --ignore-unknown --log-level log \
+  pnpm exec prettier --config ./.prettierrc.js --ignore-path ./.prettierignore --ignore-path ./.gitignore --ignore-path ./.lintignore --check --ignore-unknown --log-level log \
     $([[ "$FIX" == 'yes' ]] && echo -n "--write" ||:) \
     ${POSITIONAL_ARGS[@]}
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -78,6 +78,7 @@ function ionos.wordpress.stylelint() {
     --ignore-pattern '!**/*.css' \
     --ignore-pattern '!**/*.scss' \
     --allow-empty-input \
+    --formatter=compact \
     --no-cache \
     $([[ "$FIX" == 'yes' ]] && echo -n '--fix strict' ||:) \
     ${POSITIONAL_ARGS[@]}
@@ -215,12 +216,18 @@ function ionos.wordpress.dennis() {
   )
 
   # map file path references from within docker container to host paths
-  echo "$OUTPUT" | sed 's|Working on: /project/|Working on: ./|ig'
+  # and filter out unwanted lines (everything except untranslated string messages)
+  echo "$OUTPUT" | \
+    grep -vE '^\s|^Metadata|Statistics|Untranslated\sstrings' | \
+    grep -vE '^[0-9]+:#' | \
+    grep -vE '^[0-9]+:msgstr ""' | \
+    grep -v '^$' | \
+    sed 's|Working on: /project/|Working on: ./|ig'
 
   # abort with error if there were untranslated strings
   if echo "$OUTPUT" | grep -q 'Untranslated:\s*[1-9]'; then
     ionos.wordpress.log_error "dennis validation failed : some strings are untranslated"
-    exit 1
+    return 1
   fi
 }
 
@@ -236,8 +243,9 @@ function ionos.wordpress.pnpm() {
   ionos.wordpress.log_header "lint pnpm lock file ..."
 
   if [[ ! -f ./pnpm-lock.yaml ]]; then
-    ionos.wordpress.error_log "pnpm validation failed : ./pnpm-lock.yaml not found"
-    exit 1
+    # the filename:line notation is required for vscode tasks to jump to the correct file
+    ionos.wordpress.log_error "pnpm-lock.yaml:1 : pnpm-lock.yaml not found"
+    return 1
   fi
 
   # backup lock file
@@ -245,8 +253,9 @@ function ionos.wordpress.pnpm() {
 
   # validate lock file is valid
   if ! pnpm -s install --lockfile-only; then
-    ionos.wordpress.error_log "pnpm validation failed : pnpm lock file is outdated - please update it using 'pnpm install'"
-    exit 1
+    # the filename:line notation is required for vscode tasks to jump to the correct file
+    ionos.wordpress.log_error "pnpm-lock.yaml:1 : pnpm-lock.yaml outdated - please update it using 'pnpm install'"
+    return 1
   fi
 
   # restore lock file
@@ -275,49 +284,49 @@ function ionos.wordpress.wordpress_plugin() {
       PLUGIN_VERSION=$(grep -oP "Version:\s*\K[0-9.]*" $dir/$plugin_file)
       PACKAGE_VERSION=$(jq -r '.version' $dir/package.json)
       if [[ "$PLUGIN_VERSION" != "$PACKAGE_VERSION" ]]; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin version(=$PLUGIN_VERSION) does not match package.json version(=$PACKAGE_VERSION)"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin version(=$PLUGIN_VERSION) does not match package.json version(=$PACKAGE_VERSION)"
         exit_code=1
       fi
 
       # test 'Description' field
       if ! grep -qoP "Description:\s*.+$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Description' is missing or empty"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Description' is missing or empty"
         exit_code=1
       fi
 
       # test 'Requires at least' field
       if ! grep -qoP "Requires at least:\s*.+$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Requires at least' is missing or empty"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Requires at least' is missing or empty"
         exit_code=1
       fi
 
       # test 'Plugin URI' field
       if ! grep -qoP "Plugin URI:\s*.+$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Plugin URI' is missing or empty"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Plugin URI' is missing or empty"
         exit_code=1
       fi
 
       # test 'Update URI' field
       if ! grep -qoP "Update URI:\s*.+$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Update URI' is missing or empty"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Update URI' is missing or empty"
         exit_code=1
       fi
 
       # test 'Author' field
       if ! grep -qoP "Author:\s*.+$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Author' is missing or empty"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Author' is missing or empty"
         exit_code=1
       fi
 
       # test 'Author URI' field
       if ! grep -qoP "Author URI:\s*.+$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Author URI' is missing or empty"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Author URI' is missing or empty"
         exit_code=1
       fi
 
       # test 'Domain Path' field
       if ! grep -qoP "Domain Path:\s*/languages$" $dir/$plugin_file; then
-        ionos.wordpress.log_error "$dir/$plugin_file : plugin header 'Domain Path: /languages' is missing or invalid"
+        ionos.wordpress.log_error "$dir/$plugin_file:1 : plugin header 'Domain Path: /languages' is missing or invalid"
         exit_code=1
       fi
     done
@@ -326,8 +335,16 @@ function ionos.wordpress.wordpress_plugin() {
   return $exit_code
 }
 
+declare -A summaries=()
+
+set +e
 if [[ "${USE[@]}" =~ all|php|wp ]]; then
-  ionos.wordpress.wordpress_plugin || exit_code=1
+  if ionos.wordpress.wordpress_plugin; then
+    summaries["wp"]="WordPress $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["wp"]="WordPress $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
 fi
 
 # if [[ "${USE[@]}" =~ all|php ]]; then
@@ -335,27 +352,79 @@ fi
 # fi
 
 if [[ "${USE[@]}" =~ all|php ]]; then
-  ionos.wordpress.ecs || exit_code=1
+ if ionos.wordpress.ecs; then
+    summaries["php"]="PHP $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["php"]="PHP $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
 fi
 
 if [[ "${USE[@]}" =~ all|prettier ]]; then
-  ionos.wordpress.prettier || exit_code=1
+  if ionos.wordpress.prettier; then
+    summaries["prettier"]="Prettier $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["prettier"]="Prettier $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
 fi
 
 if [[ "${USE[@]}" =~ all|js ]]; then
-  ionos.wordpress.eslint || exit_code=1
+  if ionos.wordpress.eslint; then
+    summaries["js"]="Javascript $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["js"]="Javascript $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
 fi
 
 if [[ "${USE[@]}" =~ all|css ]]; then
-  ionos.wordpress.stylelint || exit_code=1
+  if ionos.wordpress.stylelint; then
+    summaries["css"]="CSS $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["css"]="CSS $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
 fi
 
 if [[ "${USE[@]}" =~ all|pnpm ]]; then
-  ionos.wordpress.pnpm || exit_code=1
+  if ionos.wordpress.pnpm; then
+    summaries["pnpm"]="PNPM $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["pnpm"]="PNPM $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
 fi
 
 if [[ " ${USE[@]} " =~ all|i18n ]]; then
-  ionos.wordpress.dennis || exit_code=1
+  if ionos.wordpress.dennis; then
+    summaries["i18n"]="i18n $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') was successful."
+  else
+    exit_code=1
+    summaries["i18n"]="i18n $( [[ "$FIX" == 'yes' ]] && echo 'lint fixing' ||  echo 'linting') reported errors."
+  fi
+fi
+
+echo ''
+
+error_count=0
+for key in "${!summaries[@]}"; do
+  message="${summaries[$key]}"
+
+  if [[ "$message" =~ errors ]]; then
+    error_count=$(( $error_count + 1 ))
+    echo -e "\e[31m$message\e[0m"
+  else
+    echo "$message"
+  fi
+done
+
+echo ''
+
+if [[ $error_count -gt 0 ]]; then
+  echo -e "\e[31m$error_count linter(s) reported errors.\e[0m"
+else
+  echo "Linting passed successfully."
 fi
 
 exit ${exit_code:-0}


### PR DESCRIPTION
- linter summary output in terminal

[lint-summary.webm](https://github.com/user-attachments/assets/0f81414b-69d7-4399-94dd-7c776f43e596)

- vscode problems view integration 

[vscode-tasks.webm](https://github.com/user-attachments/assets/a77ec5fd-6b3e-4165-8bf3-ee81c45cf36a)
