### PR TITLE
Fix/rector downgrading

### DIFF
--- a/packages/docker/ecs-php/ecs-config.php
+++ b/packages/docker/ecs-php/ecs-config.php
@@ -49,7 +49,9 @@ return $configure->withRules([
       '/tmp/*',
       '*/docs/packages/*',
       '**/ecs-config.php',
-      'rector-config-php7.4.php',
+      '**/rector-config-php7.4.php',
+      '**/rector-fix-types.php',
+      '**/wordpress-stubs.php',
     ]
   )
   ->withPreparedSets(

--- a/packages/docker/rector-php/rector-config-php7.4.php
+++ b/packages/docker/rector-php/rector-config-php7.4.php
@@ -12,6 +12,8 @@ use Rector\ValueObject\PhpVersion;
   - https://masteringlaravel.io/daily/2023-11-22-how-to-reference-a-php-codesniffer-ruleset-in-easycodingstandard
  */
 
+require_once __DIR__ . '/wordpress-stubs.php';
+
 return RectorConfig::configure()->withSkip([__DIR__ . '/dist/vendor', __DIR__ . '/dist/languages'])->withParallel()
   // see https://github.com/rectorphp/rector-src/blob/3ed476b9ab65958d85416e48a810b11dbaf4283a/build/config/config-downgrade.php
   //->withPHPStanConfigs([__DIR__ . '/phpstan-for-downgrade.neon'])

--- a/packages/docker/rector-php/rector-config-php7.4.php
+++ b/packages/docker/rector-php/rector-config-php7.4.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-// use Rector\ValueObject\PhpVersion;
+use Rector\ValueObject\PhpVersion;
 
 /*
   @TODO: integrate PHPCS and PHP-CS-Fixer rulesets with EasyCodingStandard instead of calling them separately in the ./scripts/lint.sh script
@@ -15,8 +15,8 @@ use Rector\Config\RectorConfig;
 return RectorConfig::configure()->withSkip([__DIR__ . '/dist/vendor', __DIR__ . '/dist/languages'])->withParallel()
   // see https://github.com/rectorphp/rector-src/blob/3ed476b9ab65958d85416e48a810b11dbaf4283a/build/config/config-downgrade.php
   //->withPHPStanConfigs([__DIR__ . '/phpstan-for-downgrade.neon'])
-
-  //->withPhpVersion(PhpVersion::PHP_83)
+  ->withPhpVersion(PhpVersion::PHP_83)
+  /*
   ->withPreparedSets(
     // deadCode: true,
     // codeQuality: true,
@@ -36,4 +36,6 @@ return RectorConfig::configure()->withSkip([__DIR__ . '/dist/vendor', __DIR__ . 
     // // composer based
     // twig: true,
     // phpunit: true,
-  )->withDowngradeSets(php74: true);
+  )
+  */
+  ->withDowngradeSets(php74: true);

--- a/packages/wp-plugin/essentials/inc/migration/index.php
+++ b/packages/wp-plugin/essentials/inc/migration/index.php
@@ -16,17 +16,14 @@ use const ionos_wordpress\essentials\PLUGIN_FILE;
 
 /**
  * wp option where the installation data is stored
- * the value is a associative array with keys from INSTALL_DATA_KEYS
+ * the value is a associative array with keys from WP_OPTION_LAST_INSTALL_DATA_KEY_* constants
  * we use a array to be able to store multiple values in the future
  */
 
 const WP_OPTION_LAST_INSTALL_DATA = 'ionos-essentials-last-install-data';
 
-// all valid keys for the installation data array
-enum INSTALL_DATA_KEYS: string
-{
-  case PLUGIN_VERSION = 'plugin-version';
-}
+// key to store the plugin version in the installation data
+const WP_OPTION_LAST_INSTALL_DATA_KEY_PLUGIN_VERSION = 'plugin-version';
 
 /*
  * we hook our migration into admin-init to check if we were installed/updated
@@ -52,11 +49,11 @@ function _uninstall()
 function _install()
 {
   $last_install_data      = \get_option(WP_OPTION_LAST_INSTALL_DATA, false);
-  $last_installed_version = $last_install_data[INSTALL_DATA_KEYS::PLUGIN_VERSION->value] ?? false;
+  $last_installed_version = $last_install_data[WP_OPTION_LAST_INSTALL_DATA_KEY_PLUGIN_VERSION] ?? false;
   $current_version        = \get_plugin_data(PLUGIN_FILE)['Version'];
 
   $current_install_data = [
-    INSTALL_DATA_KEYS::PLUGIN_VERSION->value => $current_version,
+    WP_OPTION_LAST_INSTALL_DATA_KEY_PLUGIN_VERSION => $current_version,
   ];
 
   switch ($last_installed_version) {

--- a/packages/wp-plugin/essentials/inc/migration/tests/phpunit/MigrationTest.php
+++ b/packages/wp-plugin/essentials/inc/migration/tests/phpunit/MigrationTest.php
@@ -2,9 +2,7 @@
 
 use const ionos_wordpress\essentials\migration\WP_OPTION_LAST_INSTALL_DATA;
 use const ionos_wordpress\essentials\PLUGIN_FILE;
-
-use ionos_wordpress\essentials\migration\INSTALL_DATA_KEYS;
-use ionos_wordpress\essentials\migration\_install;
+use const ionos_wordpress\essentials\migration\WP_OPTION_LAST_INSTALL_DATA_KEY_PLUGIN_VERSION;
 
 use function ionos_wordpress\essentials\migration\_install;
 
@@ -33,8 +31,8 @@ class MigrationTest extends \WP_UnitTestCase {
     $install_data = \get_option(WP_OPTION_LAST_INSTALL_DATA);
     $this->assertIsArray($install_data, 'option install data should be an array');
 
-    $this->assertArrayHasKey(INSTALL_DATA_KEYS::PLUGIN_VERSION->value, $install_data, 'plugin version should be set');
+    $this->assertArrayHasKey(WP_OPTION_LAST_INSTALL_DATA_KEY_PLUGIN_VERSION, $install_data, 'plugin version should be set');
 
-    $this->assertEquals(\get_plugin_data(PLUGIN_FILE)['Version'], $install_data[INSTALL_DATA_KEYS::PLUGIN_VERSION->value], 'plugin version should match');
+    $this->assertEquals(\get_plugin_data(PLUGIN_FILE)['Version'], $install_data[WP_OPTION_LAST_INSTALL_DATA_KEY_PLUGIN_VERSION], 'plugin version should match');
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -428,6 +428,7 @@ EOF
           --user "$DOCKER_USER" \
           -v $path/$TARGET_DIR:/project/dist \
           -v $(pwd)/packages/docker/rector-php/${RECTOR_CONFIG}.php:/project/${RECTOR_CONFIG}.php \
+          -v $(pwd)/packages/docker/rector-php/wordpress-stubs.php:/project/wordpress-stubs.php \
           ionos-wordpress/rector-php \
           --clear-cache \
           --config "${RECTOR_CONFIG}.php" \


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description

This PR fixes downgrading our plugins from PHP 8.3 to PHP 7.4 

- fixing named parameter / argument removal using rector

- refactoring enum usage where they used to toString

## PR Tasks

I have

- [x] linted the sources
- [x] updated/added tests for the changes if needed
- [x] runned successfully the tests locally

## QA Instructions, Screenshots, Recordings

- checkout the branch 

- add a `.wp-env.override.json` with following contents : 

  ```json
  {
    "phpVersion": "7.4",
    "plugins": [
    ]
  }
  ```
  
  This will configure wp-env to use PHP 7.4 and not using any plugin.
  After starting up wp-env you can upload the transpiled essentials zip archive and test it in the wp-env php 7.4 instance.
  