### PR TITLE
fix: copy phpunit file config into wp-env container

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -85,8 +85,6 @@ fi
       "afterDestroy": "./scripts/wp-env-after-destroy.sh"
     },
     "mappings": {
-      "phpunit.xml": "./phpunit/phpunit.xml",
-      "bootstrap.php": "./phpunit/bootstrap.php"
       $(mu_plugins | sed '$ s/,$//')
     }
   }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -95,17 +95,18 @@ if [[ "${USE[@]}" =~ all|php|e2e ]]; then
   if [[ ! -d "$WPENV_INSTALLPATH/WordPress" ]] || [[ "$(docker ps -q --filter "name=$(basename $WPENV_INSTALLPATH)" | wc -l)" -lt '6' ]]; then
     pnpm start
   fi
-  # ENDMARK
-fi
 
-if [[ "${USE[@]}" =~ all|php ]]; then
+  # copy phpunit files from wp-env container to phpunit-wordpress
   WORDPRESS_TEST_CONTAINER=$(docker ps -q --filter "name=tests-wordpress")
   docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" "$(pwd)/phpunit/"
 
   # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
   docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
   docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
+  # ENDMARK
+fi
 
+if [[ "${USE[@]}" =~ all|php ]]; then
   # start wp-env unit tests. provide part specific options and all positional arguments that are php files
   # (files will be converted to '--filter *TestCase' arguments to match PHPUNit expectations)
   pnpm -s run wp-env run tests-wordpress phpunit -- \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -95,14 +95,6 @@ if [[ "${USE[@]}" =~ all|php|e2e ]]; then
   if [[ ! -d "$WPENV_INSTALLPATH/WordPress" ]] || [[ "$(docker ps -q --filter "name=$(basename $WPENV_INSTALLPATH)" | wc -l)" -lt '6' ]]; then
     pnpm start
   fi
-
-  # copy phpunit files from wp-env container to phpunit-wordpress
-  WORDPRESS_TEST_CONTAINER=$(docker ps -q --filter "name=tests-wordpress")
-  docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" "$(pwd)/phpunit/"
-
-  # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
-  docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
-  docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
   # ENDMARK
 fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -99,6 +99,13 @@ if [[ "${USE[@]}" =~ all|php|e2e ]]; then
 fi
 
 if [[ "${USE[@]}" =~ all|php ]]; then
+  WORDPRESS_TEST_CONTAINER=$(docker ps -q --filter "name=tests-wordpress")
+  docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" "$(pwd)/phpunit/"
+
+  # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
+  docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
+  docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
+
   # start wp-env unit tests. provide part specific options and all positional arguments that are php files
   # (files will be converted to '--filter *TestCase' arguments to match PHPUNit expectations)
   pnpm -s run wp-env run tests-wordpress phpunit -- \

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -31,20 +31,6 @@ EOF
   )
   # ENDMARK
 
-  # MARK: copy PHPUNIT
-  # copy phpunit files from wp-env container to phpunit-wordpress
-  WORDPRESS_TEST_CONTAINER=$(docker ps -q --filter "name=tests-wordpress")
-  docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" "$(pwd)/phpunit/"
-
-  # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
-  docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
-  docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
-
-  # List files in the /var/www/html directory of the WordPress test container
-  docker exec "$WORDPRESS_TEST_CONTAINER" ls -la /var/www/html
-
-  # ENDMARK
-
   # MARK: vscode configurations generation
   # generate .vscode/launch.json
   (

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -34,11 +34,11 @@ EOF
   # MARK: copy PHPUNIT
   # copy phpunit files from wp-env container to phpunit-wordpress
   WORDPRESS_TEST_CONTAINER=$(docker ps -q --filter "name=tests-wordpress")
-  docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" ./phpunit/
+  docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" "$(pwd)/phpunit/"
 
   # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
-  docker cp ./phpunit/phpunit.xml "$WORDPRESS_TEST_CONTAINER:/var/www/html"
-  docker cp ./phpunit/bootstrap.php "$WORDPRESS_TEST_CONTAINER:/var/www/html"
+  docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html"
+  docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html"
 
   # ENDMARK
 

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -37,8 +37,8 @@ EOF
   docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" "$(pwd)/phpunit/"
 
   # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
-  docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html"
-  docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html"
+  docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
+  docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html/"
 
   # List files in the /var/www/html directory of the WordPress test container
   docker exec "$WORDPRESS_TEST_CONTAINER" ls -la /var/www/html

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -34,12 +34,11 @@ EOF
   # MARK: copy PHPUNIT
   # copy phpunit files from wp-env container to phpunit-wordpress
   WORDPRESS_TEST_CONTAINER=$(docker ps -q --filter "name=tests-wordpress")
-  docker cp $WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/ ./phpunit/
+  docker cp "$WORDPRESS_TEST_CONTAINER:/home/$USER/.composer/vendor/" ./phpunit/
 
-  # @FIXME: doesnt work for me in github ci for some reason
-  # # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
-  # # docker cp ./phpunit/phpunit.xml $WORDPRESS_TEST_CONTAINER:/var/www/html/
-  # # docker cp ./phpunit/bootstrap.php $WORDPRESS_TEST_CONTAINER:/var/www/html/
+  # copy our phpunit config and bootstrap file to the wp-env wordpress test instance instead of mapping them in wp-env.json
+  docker cp ./phpunit/phpunit.xml "$WORDPRESS_TEST_CONTAINER:/var/www/html"
+  docker cp ./phpunit/bootstrap.php "$WORDPRESS_TEST_CONTAINER:/var/www/html"
 
   # ENDMARK
 

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -40,6 +40,9 @@ EOF
   docker cp "$(pwd)/phpunit/phpunit.xml" "$WORDPRESS_TEST_CONTAINER:/var/www/html"
   docker cp "$(pwd)/phpunit/bootstrap.php" "$WORDPRESS_TEST_CONTAINER:/var/www/html"
 
+  # List files in the /var/www/html directory of the WordPress test container
+  docker exec "$WORDPRESS_TEST_CONTAINER" ls -la /var/www/html
+
   # ENDMARK
 
   # MARK: vscode configurations generation


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This pr fixes the sometimes occurring "permission denied" issue when doing `pnpm destroy`

## PR Tasks

I have

- [x] runned successfully the tests locally
