### PR TITLE
fix space on open mobile wp-menu

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/index.php
@@ -57,10 +57,13 @@ require_once __DIR__ . '/blocks/whats-new/index.php';
           display: none
         }
         #wpwrap #wpcontent {
-          margin-left: 140px;
+          margin-left: -10px;
         }
         .folded #wpwrap #wpcontent {
           margin-left: 16px;
+        }
+        .wp-responsive-open #wpbody {
+          right: -13em !important;
         }
         EOF
     );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Remove Blank space on the left side, when on mobile view.

## Related Tickets & Documents

- Related Issue #
- Closes #

## PR Tasks

I have

- [x] linted the sources

## QA Instructions, Screenshots, Recordings

Checkout branch and verify that issue is fixed.
