### PR TITLE
github rest api free update mechanism 

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/update/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/update/index.php
@@ -28,10 +28,6 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
     string $plugin_slug,
   ): array|false {
 
-    // Extract hostname from UpdateURI
-    $parsed_url = parse_url($plugin_data['UpdateURI']);
-    $hostname   = $parsed_url['host'] ?? '';
-
     if (\plugin_basename(PLUGIN_FILE) !== $plugin_slug) {
       return $update;
     }

--- a/packages/wp-plugin/ionos-essentials/inc/update/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/update/index.php
@@ -15,69 +15,57 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
 }
 */
 
-\add_filter('update_plugins_api.github.com', function (
-  array|false $update,
-  array $plugin_data,
-  string $plugin_slug,
-): array|false {
-  if (\plugin_basename(PLUGIN_FILE) !== $plugin_slug) {
-    return $update;
-  }
+\add_action('init', function() {
+  if( ! function_exists('get_plugin_data') ){
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+	}
 
-  // get the redirect URL from the UpdateURI
-  $res = \wp_remote_get($plugin_data['UpdateURI'] . '/latest', [
-    'headers' => [
-      'Accept' => 'application/json',
-    ],
-  ]);
+  $update_domain = parse_url(\get_plugin_data(PLUGIN_FILE, false, false)['UpdateURI'], PHP_URL_HOST);
 
-  // abort if the request failed or the response code is not 200 or the response body is empty
-  if ((200 !== \wp_remote_retrieve_response_code($res)) || ('' === \wp_remote_retrieve_body($res))) {
-    if ('' !== \wp_remote_retrieve_response_code($res)) {
-      // may happen for rate limit exceeded
-      error_log(
-        sprintf(
-          'Failed to fetch latest update information from "%s"(http-status=%s) : %s',
-          $plugin_data['UpdateURI'],
-          \wp_remote_retrieve_response_code($res),
-          \wp_remote_retrieve_body($res),
-        )
-      );
-    } else {
-      error_log(sprintf('Failed to download update information from "%s"', $plugin_data['UpdateURI']));
+  \add_filter('update_plugins_' . $update_domain, function (
+    array|false $update,
+    array $plugin_data,
+    string $plugin_slug,
+  ): array|false {
+
+    // Extract hostname from UpdateURI
+    $parsed_url = parse_url($plugin_data['UpdateURI']);
+    $hostname = $parsed_url['host'] ?? '';
+
+    if (\plugin_basename(PLUGIN_FILE) !== $plugin_slug) {
+      return $update;
     }
-    return $update;
-  }
 
-  $release = json_decode($res['body'], true);
+    // get the redirect URL from the UpdateURI
+    $res = \wp_remote_get($plugin_data['UpdateURI'], [
+      'headers' => [
+        'Accept' => 'application/json',
+      ],
+    ]);
 
-  // extract version from release name
-  $_              = explode('@', $release['tag_name']);
-  $version        = end($_);
-
-  // example : '/essentials-0\.\0\.4-php.*\.zip/'
-  $_                 = explode('/', $plugin_data['Name']);
-  $asset_name_regexp = '/'
-    . preg_quote(end($_), '/') // 'ionos-wordpress/essentials' => 'essentials'
-    . '-' . preg_quote($version, '/') // '0\.0\.4'
-    . '-php.*\.zip/';
-
-  // find the asset that matches the asset name regular expression
-  // and return the $update data if found
-  foreach ($release['assets'] as $asset) {
-    if (preg_match($asset_name_regexp, $asset['name'])) {
-      return [
-        'version' => $version,
-        'package' => $asset['browser_download_url'],
-        // slug is required to trigger the 'plugins_api' filter below
-        'slug' => $plugin_slug,
-      ];
+    // abort if the request failed or the response code is not 200 or the response body is empty
+    if ((200 !== \wp_remote_retrieve_response_code($res)) || ('' === \wp_remote_retrieve_body($res))) {
+      if ('' !== \wp_remote_retrieve_response_code($res)) {
+        // may happen for rate limit exceeded
+        error_log(
+          sprintf(
+            'Failed to fetch latest update information from "%s"(http-status=%s) : %s',
+            $plugin_data['UpdateURI'],
+            \wp_remote_retrieve_response_code($res),
+            \wp_remote_retrieve_body($res),
+          )
+        );
+      } else {
+        error_log(sprintf('Failed to download update information from "%s"', $plugin_data['UpdateURI']));
+      }
+      return $update;
     }
-  }
-  return $update;
-}, 10, 3);
 
-// action in_plugin_update_message-{$file}"in_plugin_update_message-{$file}"
+    $info_json = json_decode($res['body'], true);
+
+    return $info_json;
+  }, 10, 3);
+});
 
 /*
 * This filter is used to modify the plugin information that is displayed in the WordPress admin panel as plugin details.
@@ -91,17 +79,8 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
 
   $plugin_data = \get_plugin_data(ABSPATH . 'wp-content/plugins/' . $args->slug, false, false);
 
-  $result = (object) [
-    'name'     => $plugin_data['Name'],
-    'version'  => $plugin_data['Version'],
-    'slug'     => $args->slug,
-    'sections' => [
-      'changelog' => '',  // will be filled later
-    ],
-  ];
-
   // fetch changelog from github
-  $res = \wp_remote_get($plugin_data['UpdateURI'] . '/latest', [
+  $res = \wp_remote_get($plugin_data['UpdateURI'], [
     'headers' => [
       'Accept' => 'application/json',
     ],
@@ -109,39 +88,28 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
 
   // abort if the request failed or the response code is not 200 or the response body is empty
   if ((200 !== \wp_remote_retrieve_response_code($res)) || ('' === \wp_remote_retrieve_body($res))) {
+    $result = (object) [
+      'name'     => $plugin_data['Name'],
+      'version'  => $plugin_data['Version'],
+      'slug'     => $args->slug,
+      'sections' => [
+        'changelog' => '',  // will be filled later
+      ],
+    ];
+
     // abort gracefully
     // show error message including link in the changelog section
     $result->sections['changelog'] = sprintf(
-      'Failed to download <a href=\"%s\">changelog</a>(response=%s)',
-      $plugin_data['PluginURI'] . '/latest',
+      'Failed to download <a href=\"%s\">%s-info.json</a>(response status=%s)',
+      $plugin_data['UpdateURI'], $plugin_data['Name'],
       print_r(\wp_remote_retrieve_response_code($res), true),
     );
 
     return $result;
   }
 
-  $release = json_decode($res['body'], true);
-
-  $changelog_html = $release['body'];
-
-  // Basic markdown to HTML conversion (example implementation)
-  $changelog_html = htmlspecialchars($changelog_html, ENT_QUOTES, 'UTF-8');
-  $changelog_html = preg_replace('/\*\*(.*?)\*\*/', '<strong>$1</strong>', $changelog_html); // Bold
-  $changelog_html = preg_replace('/\*(.*?)\*/', '<em>$1</em>', $changelog_html); // Italic
-  $changelog_html = preg_replace('/\#\#\# (.*?)\n/', '<h3>$1</h3>', $changelog_html); // H3
-  $changelog_html = preg_replace('/\#\# (.*?)\n/', '<h2>$1</h2>', $changelog_html); // H2
-  $changelog_html = preg_replace('/\# (.*?)\n/', '<h1>$1</h1>', $changelog_html); // H1
-  // $changelog_html = preg_replace('/\n/', '<br>', $changelog_html); // Line breaks
-
-  // Unordered list parsing
-  $changelog_html = preg_replace_callback(
-    '/(?:^|\n)- (.*?)(?=\n|$)/',
-    fn ($matches) => '<li>' . $matches[1] . '</li>',
-    $changelog_html
-  );
-  $changelog_html = preg_replace('/(<li>.*?<\/li>)/s', '<ul>$1</ul>', $changelog_html);
-
-  $result->sections['changelog'] = $changelog_html;
+  $result = (object)json_decode($res['body'], true);
+  $result->name = $plugin_data['Name'];
 
   return $result;
 }, 10, 3);

--- a/packages/wp-plugin/ionos-essentials/inc/update/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/update/index.php
@@ -15,87 +15,96 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
 }
 */
 
-\add_filter('update_plugins_github.com', function (
-  array|false $update,
-  array $plugin_data,
-  string $plugin_slug,
-): array|false {
+\add_filter(
+  hook_name: 'update_plugins_github.com',
+  accepted_args: 3,
+  callback: function (
+    array|false $update,
+    array $plugin_data,
+    string $plugin_slug,
+  ): array|false {
 
-  if (\plugin_basename(PLUGIN_FILE) !== $plugin_slug) {
+    if (\plugin_basename(PLUGIN_FILE) !== $plugin_slug) {
+      return $update;
+    }
+
+    // get the redirect URL from the UpdateURI
+    $res = \wp_remote_get($plugin_data['UpdateURI'], [
+      'headers' => [
+        'Accept' => 'application/json',
+      ],
+    ]);
+
+    // if the request was successful
+    if ((200 === \wp_remote_retrieve_response_code($res)) || ('' !== \wp_remote_retrieve_body($res))) {
+      $info_json = json_decode($res['body'], true);
+
+      return $info_json;
+    }
+
+    if ((200 !== \wp_remote_retrieve_response_code($res))) {
+      error_log(
+        sprintf(
+          'Failed to fetch latest update information from "%s"(http-status=%s) : %s',
+          $plugin_data['UpdateURI'],
+          \wp_remote_retrieve_response_code($res),
+          '' !== \wp_remote_retrieve_body($res) ? \wp_remote_retrieve_body($res) : 'response body was empty',
+        )
+      );
+    }
+
     return $update;
   }
-
-  // get the redirect URL from the UpdateURI
-  $res = \wp_remote_get($plugin_data['UpdateURI'], [
-    'headers' => [
-      'Accept' => 'application/json',
-    ],
-  ]);
-
-  // if the request was successful
-  if ((200 === \wp_remote_retrieve_response_code($res)) || ('' !== \wp_remote_retrieve_body($res))) {
-    $info_json = json_decode($res['body'], true);
-
-    return $info_json;
-  }
-
-  if ((200 !== \wp_remote_retrieve_response_code($res))) {
-    error_log(
-      sprintf(
-        'Failed to fetch latest update information from "%s"(http-status=%s) : %s',
-        $plugin_data['UpdateURI'],
-        \wp_remote_retrieve_response_code($res),
-        '' !== \wp_remote_retrieve_body($res) ? \wp_remote_retrieve_body($res) : 'response body was empty',
-      )
-    );
-    return $update;
-  }
-}, 10, 3);
+);
 
 /*
 * This filter is used to modify the plugin information that is displayed in the WordPress admin panel as plugin details.
 *
 * see https://gist.github.com/CruelDrool/4cc70b819a33793396456c5ddb81781d
 */
-\add_filter('plugins_api', function (\stdClass|false $result, string $action, \stdClass $args): \stdClass|false {
-  if (! isset($args->slug) || "{$args->slug}" !== \plugin_basename(PLUGIN_FILE)) {
-    return $result;
-  }
+\add_filter(
+  hook_name: 'plugins_api',
+  accepted_args: 3,
+  callback: function (\stdClass|false $result, string $action, \stdClass $args): \stdClass|false {
+    if (! isset($args->slug) || "{$args->slug}" !== \plugin_basename(PLUGIN_FILE)) {
+      return $result;
+    }
 
-  $plugin_data = \get_plugin_data(ABSPATH . 'wp-content/plugins/' . $args->slug, false, false);
+    $plugin_data = \get_plugin_data(ABSPATH . 'wp-content/plugins/' . $args->slug, false, false);
 
-  // fetch changelog from github
-  $res = \wp_remote_get($plugin_data['UpdateURI'], [
-    'headers' => [
-      'Accept' => 'application/json',
-    ],
-  ]);
-
-  // abort if the request failed or the response code is not 200 or the response body is empty
-  if ((200 !== \wp_remote_retrieve_response_code($res)) || ('' === \wp_remote_retrieve_body($res))) {
-    $result = (object) [
-      'name'     => $plugin_data['Name'],
-      'version'  => $plugin_data['Version'],
-      'slug'     => $args->slug,
-      'sections' => [
-        'changelog' => '',  // will be filled later
+    // fetch changelog from github
+    $res = \wp_remote_get($plugin_data['UpdateURI'], [
+      'headers' => [
+        'Accept' => 'application/json',
       ],
-    ];
+    ]);
 
-    // abort gracefully
-    // show error message including link in the changelog section
-    $result->sections['changelog'] = sprintf(
-      'Failed to download <a href=\"%s\">%s-info.json</a>(response status=%s)',
-      $plugin_data['UpdateURI'],
-      $plugin_data['Name'],
-      print_r(\wp_remote_retrieve_response_code($res), true),
-    );
+    // abort if the request failed or the response code is not 200 or the response body is empty
+    if ((200 !== \wp_remote_retrieve_response_code($res)) || ('' === \wp_remote_retrieve_body($res))) {
+      $result = (object) [
+        'name'     => $plugin_data['Name'],
+        'version'  => $plugin_data['Version'],
+        'slug'     => $args->slug,
+        'sections' => [
+          'changelog' => '',  // will be filled later
+        ],
+      ];
+
+      // abort gracefully
+      // show error message including link in the changelog section
+      $result->sections['changelog'] = sprintf(
+        'Failed to download <a href=\"%s\">%s-info.json</a>(response status=%s)',
+        $plugin_data['UpdateURI'],
+        $plugin_data['Name'],
+        print_r(\wp_remote_retrieve_response_code($res), true),
+      );
+
+      return $result;
+    }
+
+    $result       = (object) json_decode($res['body'], true);
+    $result->name = $plugin_data['Name'];
 
     return $result;
   }
-
-  $result       = (object) json_decode($res['body'], true);
-  $result->name = $plugin_data['Name'];
-
-  return $result;
-}, 10, 3);
+);

--- a/packages/wp-plugin/ionos-essentials/inc/update/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/update/index.php
@@ -15,10 +15,10 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
 }
 */
 
-\add_action('init', function() {
-  if( ! function_exists('get_plugin_data') ){
-		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-	}
+\add_action('init', function () {
+  if (! function_exists('get_plugin_data')) {
+    require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+  }
 
   $update_domain = parse_url(\get_plugin_data(PLUGIN_FILE, false, false)['UpdateURI'], PHP_URL_HOST);
 
@@ -30,7 +30,7 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
 
     // Extract hostname from UpdateURI
     $parsed_url = parse_url($plugin_data['UpdateURI']);
-    $hostname = $parsed_url['host'] ?? '';
+    $hostname   = $parsed_url['host'] ?? '';
 
     if (\plugin_basename(PLUGIN_FILE) !== $plugin_slug) {
       return $update;
@@ -101,14 +101,15 @@ if (false !== array_search(\wp_get_development_mode(), ['all', 'plugin'], true))
     // show error message including link in the changelog section
     $result->sections['changelog'] = sprintf(
       'Failed to download <a href=\"%s\">%s-info.json</a>(response status=%s)',
-      $plugin_data['UpdateURI'], $plugin_data['Name'],
+      $plugin_data['UpdateURI'],
+      $plugin_data['Name'],
       print_r(\wp_remote_retrieve_response_code($res), true),
     );
 
     return $result;
   }
 
-  $result = (object)json_decode($res['body'], true);
+  $result       = (object) json_decode($res['body'], true);
   $result->name = $plugin_data['Name'];
 
   return $result;

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials.php
@@ -7,7 +7,7 @@
  * Requires Plugins:
  * Requires PHP:      8.3
  * Version:           0.2.1
- * Update URI:        https://api.github.com/repos/IONOS-WordPress/ionos-wordpress/releases
+ * Update URI:        https://github.com/IONOS-WordPress/ionos-wordpress/releases/download/%40ionos-wordpress%2Flatest/ionos-essentials-info.json
  * Plugin URI:        https://github.com/IONOS-WordPress/ionos-wordpress/tree/main/packages/wp-plugin/essentials
  * License:           GPL-2.0-or-later
  * Author:            IONOS Group

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,9 @@
 #   - semantic versions in assets will be renamed to 'latest'
 #       (example: ionos-essentials-0.1.1-php7.4.zip => ionos-essentials-latest-php7.4.zip)
 #   - release note will be set to the 'pre-release' release url and title to make it easier to find the origin release
+#   - a info.json file will be created/updated for each plugin asset (ionos-essentials-0.1.1-php7.4.zip => ionos-essentials-info.json)
+#       containing { version, slug, package, sections: { changelog } }, where package points to the download url
+#       of the 'latest' flagged release (example: https://.../ionos-essentials-0.1.1-php7.4.zip)
 # - remove the 'pre-release' flag from the release used to populate the 'latest' release and flag it 'latest'
 #
 # afterwards the 'latest' release will contain the same assets as the 'pre-release' release


### PR DESCRIPTION
## Description

pr introduces the `info.json` feature. 

this file will be used to transport version,slug, changelog and download url of the latest release.

benefits of the pr are : 

- plugin update mechanism could be massively simplified
- we can track (then) download statistics using plain curl per asset (aka plugin version) 
  
  you can test it in this fork `curl -i https://api.github.com/repos/lgersman/ionos-wordpress/releases -H "Accept: application/vnd.github.manifold-preview+json"`

## PR checklist

- [x] lint + lint-fix
- [x] tests run locally
- [x] updated the documentation if necessary