### PR TITLE
add logic to split deeplinks-elements in always two rows

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/deep-links/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/deep-links/index.php
@@ -71,7 +71,7 @@ function render_callback()
   <div class="wp-block-column deep-links">
       <h3 class="wp-block-heading">%s</h3>
       <p>%s</p>
-    <div class="wp-block-group">
+    <div class="wp-block-group" id="deeplinks-elements">
     %s
     </div>
   </div>';

--- a/packages/wp-plugin/ionos-essentials/src/dashboard/blocks/deep-links/block.json
+++ b/packages/wp-plugin/ionos-essentials/src/dashboard/blocks/deep-links/block.json
@@ -13,5 +13,6 @@
   },
   "textdomain": "ionos-essentials",
   "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
   "style": "file:./index.css"
 }

--- a/packages/wp-plugin/ionos-essentials/src/dashboard/blocks/deep-links/deeplinks-style.scss
+++ b/packages/wp-plugin/ionos-essentials/src/dashboard/blocks/deep-links/deeplinks-style.scss
@@ -3,7 +3,7 @@
   .wp-block-group {
     padding: 0 0 0 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(min(250px, 100%), 1fr));
+    grid-template-rows: repeat(2, auto);
     gap: 0.8rem;
     min-height: 0;
     margin-top: var(--wp--preset--spacing--40);

--- a/packages/wp-plugin/ionos-essentials/src/dashboard/blocks/deep-links/view.js
+++ b/packages/wp-plugin/ionos-essentials/src/dashboard/blocks/deep-links/view.js
@@ -1,0 +1,15 @@
+function updateColumns() {
+  const grid = document.getElementById('deeplinks-elements');
+  const itemWidth = 180;
+  const containerWidth = grid.offsetWidth;
+  const columns = Math.floor(containerWidth / itemWidth);
+  const totalItems = grid.children.length;
+  const rows = 2;
+  const maxColumns = Math.ceil(totalItems / rows);
+  const finalColumns = Math.min(columns, maxColumns);
+
+  grid.style.gridTemplateColumns = `repeat(${finalColumns}, 1fr)`;
+}
+
+window.addEventListener('DOMContentLoaded', updateColumns);
+window.addEventListener('resize', updateColumns);


### PR DESCRIPTION
## Description

Deeplinks items are always shown in only two rows and the elements are arranged as equally as possible.

## PR checklist

- [x] lint + lint-fix
- [x] tests run locally
