### PR TITLE
fix(i18n): remove duplicate comments

### DIFF
--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-de_DE.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-de_DE.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Nutzen Sie diese einfache Navigation zu den häufigsten Funktionen und Tools in WordPress."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Übersicht"
 
@@ -214,7 +213,6 @@ msgstr "Übersicht"
 msgid "Create Page"
 msgstr "Seite erstellen"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Logo hinzufügen"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Nutzen Sie Ihre inkludierte E-Mail-Adresse passend zur Ihrer eigenen Website und Domain."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Kontakt-Formular einrichten"
 
@@ -292,7 +289,6 @@ msgstr "Verbinden Sie Ihre Social-Media-Profile mit Ihrer Website und erweitern 
 msgid "Connect Social Media"
 msgstr "Social Media verbinden"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Favicon hinzufügen"
@@ -407,8 +403,6 @@ msgstr "Footer editieren"
 msgid "Dismiss"
 msgstr "Nicht mehr anzeigen"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Überprüfung auf WordPress-spezifische Schwachstellen und Bedrohungen"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-de_DE_formal.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-de_DE_formal.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Nutzen Sie diese einfache Navigation zu den häufigsten Funktionen und Tools in WordPress."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Übersicht"
 
@@ -214,7 +213,6 @@ msgstr "Übersicht"
 msgid "Create Page"
 msgstr "Seite erstellen"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Logo hinzufügen"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Nutzen Sie Ihre inkludierte E-Mail-Adresse passend zur Ihrer eigenen Website und Domain."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Kontakt-Formular einrichten"
 
@@ -292,7 +289,6 @@ msgstr "Verbinden Sie Ihre Social-Media-Profile mit Ihrer Website und erweitern 
 msgid "Connect Social Media"
 msgstr "Social Media verbinden"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Favicon hinzufügen"
@@ -407,8 +403,6 @@ msgstr "Footer editieren"
 msgid "Dismiss"
 msgstr "Nicht mehr anzeigen"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Überprüfung auf WordPress-spezifische Schwachstellen und Bedrohungen"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-en_US.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-en_US.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Easily navigate to frequently used features and tools."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Overview"
 
@@ -214,7 +213,6 @@ msgstr "Overview"
 msgid "Create Page"
 msgstr "Create Page"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Add Logo"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Set up your included email account and integrate it with your website."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Set Up Contact Form"
 
@@ -292,7 +289,6 @@ msgstr "Connect your social media profiles to your website and expand your onlin
 msgid "Connect Social Media"
 msgstr "Connect Social Media"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Add Favicon"
@@ -407,8 +403,6 @@ msgstr "Edit Footer"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Scan for WordPress specific threats and vulnerabilities"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-es_ES.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-es_ES.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Accede fácilmente a las funciones y herramientas más utilizadas."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Vista general"
 
@@ -214,7 +213,6 @@ msgstr "Vista general"
 msgid "Create Page"
 msgstr "Crear página"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Añadir logotipo"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Configure su cuenta de correo electrónico incluida e intégrela con su sitio web."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Configurar formulario de contacto"
 
@@ -292,7 +289,6 @@ msgstr "Conecta tus perfiles en las redes sociales a tu sitio web y amplía tu p
 msgid "Connect Social Media"
 msgstr "Conectar las redes sociales"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Añadir favicono"
@@ -407,8 +403,6 @@ msgstr "Editar pie de página"
 msgid "Dismiss"
 msgstr "No volver a mostrar"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Escaneo de vulnerabilidades"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-es_MX.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-es_MX.po
@@ -99,7 +99,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Configure su cuenta de correo electrónico incluida e intégrela con su sitio web."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Configurar formulario de contacto"
 
@@ -119,7 +118,6 @@ msgstr "Lance su tienda en línea ahora con un asistente de configuración guiad
 msgid "Start Setup"
 msgstr "Iniciar configuración"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Añadir logotipo"
@@ -152,7 +150,6 @@ msgstr "Conecte sus perfiles en las redes sociales a su sitio web y amplíe su p
 msgid "Connect Social Media"
 msgstr "Conectar las redes sociales"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Añadir Favicon"
@@ -213,8 +210,6 @@ msgstr "Enlaces rápidos"
 msgid "Easily navigate to frequently used features and tools."
 msgstr "Navegue fácilmente a las funciones y herramientas más utilizadas."
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Búsqueda de amenazas y vulnerabilidades específicas de WordPress"
@@ -299,7 +294,6 @@ msgstr "Resultados de la exploración de vulnerabilidades"
 msgid "We've added scan results directly to your dashboard, giving you instant visibility into potential security risks."
 msgstr "Hemos añadido los resultados de los análisis directamente a su panel de control, lo que le ofrece una visibilidad instantánea de los posibles riesgos para la seguridad."
 
-#: inc/dashboard/index.php
 #: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Visión general"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-fr_FR.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-fr_FR.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Naviguez facilement vers les fonctions et les outils les plus fréquemment utilisés."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
@@ -214,7 +213,6 @@ msgstr "Vue d'ensemble"
 msgid "Create Page"
 msgstr "Créer une page"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Ajouter un logo"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Configurez votre compte de messagerie et intégrez-le à votre site Web."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Créer un formulaire de contact"
 
@@ -292,7 +289,6 @@ msgstr "Connectez vos profils de médias sociaux à votre site Web et développe
 msgid "Connect Social Media"
 msgstr "Connecter les médias sociaux"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Ajouter un Favicon"
@@ -407,8 +403,6 @@ msgstr "Modifier le bas de page"
 msgid "Dismiss"
 msgstr "Ignorer"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Analyse des menaces et vulnérabilités spécifiques à WordPress"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-it_IT.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-it_IT.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Accedi facilmente alle funzioni e agli strumenti utilizzati più frequentemente."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Panoramica"
 
@@ -214,7 +213,6 @@ msgstr "Panoramica"
 msgid "Create Page"
 msgstr "Crea pagina"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Aggiungi un logo"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Configura il tuo account e-mail e integralo con il tuo sito web."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Configura modulo di contatto"
 
@@ -292,7 +289,6 @@ msgstr "Collega i profili social al tuo sito web e amplia la tua presenza online
 msgid "Connect Social Media"
 msgstr "Collega social media"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Aggiungi una Favicon"
@@ -407,8 +403,6 @@ msgstr "Modifica il piè di pagina"
 msgid "Dismiss"
 msgstr "Ignora"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Scansione delle vulnerabilità"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-nl_NL.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-nl_NL.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Navigeer eenvoudig naar vaak gebruikte functies en tools."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Overzicht"
 
@@ -214,7 +213,6 @@ msgstr "Overzicht"
 msgid "Create Page"
 msgstr "Pagina maken"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Logo toevoegen"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Configureer je inbegrepen e-mailaccount in en integreer het in je website."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Contactformulier instellen"
 
@@ -292,7 +289,6 @@ msgstr "Verbind je social media-profielen met je website en vergroot je online z
 msgid "Connect Social Media"
 msgstr "Social media verbinden"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Favicon toevoegen"
@@ -407,8 +403,6 @@ msgstr "Footer bewerken"
 msgid "Dismiss"
 msgstr "Sluiten"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Scan je WordPress voor bedreigingen en kwetsbaarheden"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-pl_PL.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-pl_PL.po
@@ -208,7 +208,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Łatwa nawigacja do często używanych funkcji i narzędzi."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Przegląd"
 
@@ -216,7 +215,6 @@ msgstr "Przegląd"
 msgid "Create Page"
 msgstr "Utwórz stronę"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Dodaj logo"
@@ -262,7 +260,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Skonfiguruj dołączone konto e-mail i zintegruj je ze swoją witryną."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Konfiguracja formularza kontaktowego"
 
@@ -294,7 +291,6 @@ msgstr "Połącz swoje profile w mediach społecznościowych z witryną i zwięk
 msgid "Connect Social Media"
 msgstr "Połącz media społecznościowe"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Dodaj Favicon"
@@ -409,8 +405,6 @@ msgstr "Edytuj stopkę"
 msgid "Dismiss"
 msgstr "Odrzucić"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Skanowanie w poszukiwaniu zagrożeń i luk w zabezpieczeniach WordPress"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-sv_SE.po
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials-sv_SE.po
@@ -206,7 +206,6 @@ msgid "Easily navigate to frequently used features and tools."
 msgstr "Navigera enkelt till frekvent använda funktioner och verktyg."
 
 #: inc/dashboard/index.php
-#: inc/dashboard/index.php
 msgid "Overview"
 msgstr "Översikt"
 
@@ -214,7 +213,6 @@ msgstr "Översikt"
 msgid "Create Page"
 msgstr "Skapa sida"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr "Lägg till logotyp"
@@ -260,7 +258,6 @@ msgid "Set up your included email account and integrate it with your website."
 msgstr "Ställ in ditt inkluderade e-postkonto och integrera det med din webbplats."
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr "Skapa ett kontaktformulär"
 
@@ -292,7 +289,6 @@ msgstr "Anslut dina sociala mediekonton till din webbplats och utöka din digita
 msgid "Connect Social Media"
 msgstr "Anslut sociala medier"
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr "Lägg till favicon"
@@ -407,8 +403,6 @@ msgstr "Redigera sidfot"
 msgid "Dismiss"
 msgstr "Avvisa"
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr "Skanna efter WordPress-specifika hot och sårbarheter"

--- a/packages/wp-plugin/ionos-essentials/languages/ionos-essentials.pot
+++ b/packages/wp-plugin/ionos-essentials/languages/ionos-essentials.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Essentials 1.0.3\n"
+"Project-Id-Version: Essentials 1.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-05-07T10:14:04+00:00\n"
+"POT-Creation-Date: 2025-05-16T10:43:01+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: ionos-essentials\n"
@@ -120,7 +120,6 @@ msgid "Setup Email Account"
 msgstr ""
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Set Up Contact Form"
 msgstr ""
 
@@ -153,7 +152,6 @@ msgid "Install now"
 msgstr ""
 
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Logo"
 msgstr ""
 
@@ -185,7 +183,6 @@ msgstr ""
 msgid "Connect Social Media"
 msgstr ""
 
-#: inc/dashboard/blocks/next-best-actions/class-nba.php
 #: inc/dashboard/blocks/next-best-actions/class-nba.php
 msgid "Add Favicon"
 msgstr ""
@@ -251,8 +248,6 @@ msgstr ""
 msgid "Easily navigate to frequently used features and tools."
 msgstr ""
 
-#: inc/dashboard/blocks/vulnerability/render.php
-#: inc/dashboard/blocks/vulnerability/render.php
 #: inc/dashboard/blocks/vulnerability/render.php
 msgid "Scan for WordPress specific threats and vulnerabilities"
 msgstr ""
@@ -347,7 +342,6 @@ msgstr ""
 msgid "We've added scan results directly to your dashboard, giving you instant visibility into potential security risks."
 msgstr ""
 
-#: inc/dashboard/index.php
 #: inc/dashboard/index.php
 msgid "Overview"
 msgstr ""

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -375,6 +375,7 @@ EOF
     # strip line numbers from comments in .pot and .po files
     for po_file in $(find "./packages/$1/" -name "*.po" -or -name "*.pot" -type f); do
       sed -i -e 's/^\(#:.*\):[0-9]\+/\1/g' $po_file
+      sed -i -e '/^#:/{$!N;/^\(#:.*\)\n\1$/!P;D}' $po_file
     done
 
     # make-pot regenerates the pot file even if no localization changes are


### PR DESCRIPTION
## Description

an attempt to remove duplicate comments from po files. they are left after we remove the line numbers and will be removed by lint-fix:i18n / deepl / potrans

if there is an easier way to achieve the same in bash, feel free to suggest :)

## PR checklist

- [x] lint + lint-fix
- [x] updated/added tests
- [x] tests run locally
- [x] updated the documentation if necessary

## [optional] QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

_If the ui was changed by PR please provide a before and after screenshot_
