### PR TITLE
fix(ci): build and push devcontainer only for main and develop

### DIFF
--- a/.github/workflows/build-devcontainer-image.yaml
+++ b/.github/workflows/build-devcontainer-image.yaml
@@ -37,6 +37,8 @@ jobs:
         id: image_name
 
       - name: Login to GitHub Container Registry
+        # devcontainer step that builds and pushes to registry is only needed for main and develop
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -45,12 +47,8 @@ jobs:
 
       - name: Build dev container and push to GitHub Container Registry
         uses: devcontainers/ci@v0.3
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
         with:
-          # push image only if the branch is main and the event is push
-          refFilterForPush: |
-            refs/heads/main
-            refs/heads/develop
-          eventFilterForPush: push
           imageName: ${{ steps.image_name.outputs.image_name }}
           runCmd: |
             php --version


### PR DESCRIPTION
## Description

for feature branches the devcontainer build in the first job wasnt reused because we cannot spam the registry with images. thats why we can skip the step in the first place

## PR checklist

- [ ] lint + lint-fix
- [ ] updated/added tests
- [ ] tests run locally
- [ ] updated the documentation if necessary

## [optional] QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

_If the ui was changed by PR please provide a before and after screenshot_
