### PR TITLE
GPHWPP-3951 - fix wrong paths to wp plugin "essentials"  to "ionos-essenti…

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
           "pattern": [
             /*
     ------------------------------------------------------------------------
-    packages/wp-plugin/essentials/src/dashboard/blocks/vulnerability/render.php:52
+    packages/wp-plugin/ionos-essentials/src/dashboard/blocks/vulnerability/render.php:52
     ------------------------------------------------------------------------
     Use Yoda Condition checks, you must.
 
@@ -66,7 +66,7 @@
           "pattern": [
             /*
     ------------------------------------------------------------------------
-    packages/wp-plugin/essentials/src/dashboard/blocks/vulnerability/render.php:52
+    packages/wp-plugin/ionos-essentials/src/dashboard/blocks/vulnerability/render.php:52
     ------------------------------------------------------------------------
     Use Yoda Condition checks, you must.
 
@@ -198,7 +198,7 @@
           "fileLocation": ["relative", "${workspaceFolder}"],
           "pattern": [
             /*
->>> Working on: ./packages/wp-plugin/essentials/languages/ionos-essentials-es_ES.po
+>>> Working on: ./packages/wp-plugin/ionos-essentials/languages/ionos-essentials-es_ES.po
 118:msgid "Add new page"
 211:msgid "Some other string"
                 */
@@ -234,7 +234,7 @@
           "fileLocation": ["relative", "${workspaceFolder}"],
           "pattern": [
             /*
->>> Working on: ./packages/wp-plugin/essentials/languages/ionos-essentials-es_ES.po
+>>> Working on: ./packages/wp-plugin/ionos-essentials/languages/ionos-essentials-es_ES.po
 118:msgid "Add new page"
 211:msgid "Some other string"
                 */

--- a/docs/4-lint.md
+++ b/docs/4-lint.md
@@ -13,7 +13,6 @@ Both linting commands are implemented in `./scripts/lint.sh`.
 - PHP is linted with a combination of [WordPress Coding Standard rules](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/) and [easy-coding-standard](https://github.com/easy-coding-standard/easy-coding-standard)
 
   [easy-coding-standard](https://github.com/easy-coding-standard/easy-coding-standard) is a linter capable if reusing `PHPCS` and `PHPCF` rules making it easier to configure and use. Most importantly, it allows to fix _almost any formatting errors_ automatically saving us a lot of time.
-
   - WordPress specific [WordPress Coding Standard rules](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/) rules are not yet integrated in the `easy-coding-standard` configuration but it's planned for the future. That's why the `./scripts/lint.sh` script also runs `phpcs` directly.
 
   - Plugin entry files (like `./packages/wp-plugin/ionos-essentials/ionos-essentials.php`) are also linted to contain the required WordPress plugin metadata using `./scripts/lint.sh`.
@@ -32,12 +31,11 @@ Both linting commands are implemented in `./scripts/lint.sh`.
 
 - `./.lintignore` can be used to disable linting. It will be consumed by `stylelint`, `eslint` and `prettier`.
 
-  Disabling linting for certain files makes especially sense for files that are under GIT control but machine generated (like `packages/wp-plugin/essentials/inc/dashboard/data/ionos/rendered-skeleton.html`)
+  Disabling linting for certain files makes especially sense for files that are under GIT control but machine generated (like `packages/wp-plugin/ionos-essentials/inc/dashboard/data/ionos/rendered-skeleton.html`)
 
   > Files matched by `.gitignore` will be automatically ignored by the linters. They don't need to be additionally added to `./.lintignore`
 
 - `./ecs-config.php` contains the configuration for PHP linting using `easy-coding-standard`.
-
   - Right now it's configured to use the `PSR12` (this is the latest official PHP Coding standard), `symplify` (https://github.com/easy-coding-standard/easy-coding-standard/blob/main/config/set/symplify.php) and a few further settings for dead code detection etc.
 
   - `PHPCS` is - as of now - also used for executing WordPress specific `PHPCS` rules detecting misuse of WordPress functions and paradigms. The configuration is done in `./packages/docker/ecs-php/ruleset.xml`.

--- a/docs/5-test.md
+++ b/docs/5-test.md
@@ -29,11 +29,9 @@ Example: packages/wp-plugin/test-plugin/src/feature-1/blocks/block-1/components/
   react/storybook tests utilize playwright to test the components in storybook.
 
   **For frontend testing we can use the same framework - playwright 🙌**
-
   - Run tests continuously when files change : `pnpm watch -- pnpm test:react`
 
   - vscode supports running tests by clicking on the play button in the test file.
-
     - same same for debugging tests.
 
     > [!TIP]
@@ -47,14 +45,13 @@ Example: packages/wp-plugin/test-plugin/src/feature-1/blocks/block-1/components/
 
 > phpunit test are identified by file name convention (`*Test.php`)
 
-Example: `packages/wp-plugin/essentials/inc/dashboard/tests/phpunit/AcceptanceTest.php`
+Example: `packages/wp-plugin/ionos-essentials/inc/dashboard/tests/phpunit/AcceptanceTest.php`
 
 - run phpunit tests : `pnpm test:php`
 
 - run when ever you changed a file : `pnpm watch -- pnpm test:php`
 
 - debug phpunit tests :
-
   - start `wp-env` launch configuration in vscode
 
   - start phpunit tests `pnpm test:php`
@@ -72,11 +69,9 @@ Example: `./packages/wp-plugin/test-plugin/tests/e2e/example.spec.js`
   or even simpler `pnpm run test:e2e example.spec.js` (paths can be skipped ion Playwright)
 
 - run whenever you changed a file : `pnpm watch -- pnpm test:e2e`
-
   - run a single e2e test without rebuilding and checking wp-env is alive in playwright debug mode : `pnpm exec playwright test -c ./playwright.config.js --debug ./packages/wp-plugin/test-plugin/tests/e2e/example.spec.js`
 
 - vscode supports running e2e tests by clicking on the play button in the test file.
-
   - same same for debugging tests.
 
   > [!TIP]

--- a/packages/docker/potrans/README.md
+++ b/packages/docker/potrans/README.md
@@ -17,5 +17,5 @@ See [potrans](https://github.com/OzzyCzech/potrans) homepage for all options.
 ## Example usage
 
 ```bash
-docker run -q -it --rm --user "$(id -u $USER):$(id -g $USER)" -v $(pwd):/project ionos-wordpress/potrans deepl --from="en" --to="de_DE" --no-cache --apikey='your-deepl-api-key' packages/wp-plugin/essentials/languages/essentials-de_DE.po packages/wp-plugin/essentials/languages/
+docker run -q -it --rm --user "$(id -u $USER):$(id -g $USER)" -v $(pwd):/project ionos-wordpress/potrans deepl --from="en" --to="de_DE" --no-cache --apikey='your-deepl-api-key' packages/wp-plugin/ionos-essentials/languages/essentials-de_DE.po packages/wp-plugin/ionos-essentials/languages/
 ```

--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/README.md
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/README.md
@@ -1,32 +1,11 @@
 # Dashboard feature
 
-This is a wordpress plugin that provides a dashboard for our customers.
-The dashboards can be created and edited using gutenberg.
+This feature provides a dashboard for our customers.
 
-### show dashboard
+## snippets
 
-http://localhost:8888/wp-admin/admin.php?page=custom-page
+- show dashboard : http://localhost:8888/wp-admin/
 
-### edit dashboard
+- reset nba actions : `pnpm wp-env run cli wp option delete ionos_nba_status`
 
-http://localhost:8888/wp-admin/edit.php?post_type=ionos_dashboard
-
-## concepts
-
-### code split
-
-The plugin code is split into two parts resembling the two features above.
-To be able to edit and save the dashboard(s), the file `packages/wp-plugin/essentials/inc/dashboard/editor.php` is needed.
-
-If the file is not available, the dashboard can still be viewed but not edited.
-In the production release, the file is not included in the release and the dashboard can only be viewed.
-
-For simply being able to view the dashboard (our MVP customer use case), the main plugin file is enough.
-
-### reset nba actions
-
-`pnpm wp-env run cli wp option delete ionos_nba_status`
-
-### set wpscan token
-
-`pnpm wp-env run cli wp option update ionos_security_wpscan_token random_invalid_token123 --allow-root`
+- set wpscan token : `pnpm wp-env run cli wp option update ionos_security_wpscan_token random_invalid_token123 --allow-root`

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials.php
@@ -8,7 +8,7 @@
  * Requires PHP:      8.3
  * Version:           1.0.9
  * Update URI:        https://github.com/IONOS-WordPress/ionos-wordpress/releases/download/%40ionos-wordpress%2Flatest/ionos-essentials-info.json
- * Plugin URI:        https://github.com/IONOS-WordPress/ionos-wordpress/tree/main/packages/wp-plugin/essentials
+ * Plugin URI:        https://github.com/IONOS-WordPress/ionos-wordpress/tree/main/packages/wp-plugin/ionos-essentials
  * License:           GPL-2.0-or-later
  * Author:            IONOS Group
  * Author URI:        https://www.ionos-group.com/brands.html

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -498,7 +498,7 @@ function ionos.wordpress.build_workspace_package() {
   local type="${path%/*}"
   # (example : essentials)
   local name="${path#*/}"
-  # (example : [curent-dir]/packages/wp-plugin/essentials)
+  # (example : [curent-dir]/packages/wp-plugin/ionos-essentials)
   local package_path="$(pwd)/packages/$path"
 
   ionos.wordpress.log_header "building workspace package ./packages/$path"

--- a/scripts/rector-fix-types.sh
+++ b/scripts/rector-fix-types.sh
@@ -13,7 +13,7 @@ docker run \
   $DOCKER_FLAGS \
   --rm \
   --user "$DOCKER_USER" \
-  -v $(pwd)/packages/wp-plugin/essentials:/project/dist \
+  -v $(pwd)/packages/wp-plugin/ionos-essentials:/project/dist \
   -v $(pwd)/packages/docker/rector-php/rector-fix-types.php:/project/rector-fix-types.php \
   ionos-wordpress/rector-php \
   --clear-cache \


### PR DESCRIPTION
## Description

Fixes wrong paths to wp plugin "essentials"  to "ionos-essentials.

I have already implemented ticket backlog GPHWPP-3951 by mistake.

But it only took 5 minutes 🤪

## PR checklist

- [x] tests run locally
