### PR TITLE
refactor: reenable strict GlobalVariablesOverrideSniff

### DIFF
--- a/packages/docker/ecs-php/ecs-config.php
+++ b/packages/docker/ecs-php/ecs-config.php
@@ -82,7 +82,7 @@ return $configure->withRules([
   ->withConfiguredRule(BinaryOperatorSpacesFixer::class, [
     'default' => 'align',
   ])
-  ->withConfiguredRule(GlobalVariablesOverrideSniff::class, [
-    'treat_files_as_scoped' => true,
-  ])
+  // ->withConfiguredRule(GlobalVariablesOverrideSniff::class, [
+  //   'treat_files_as_scoped' => true,
+  // ])
 ;

--- a/packages/docker/ecs-php/ecs-config.php
+++ b/packages/docker/ecs-php/ecs-config.php
@@ -3,7 +3,6 @@
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
-use WordPressCS\WordPress\Sniffs\WP\GlobalVariablesOverrideSniff;
 use WordPressCS\WordPress\Sniffs\Security\EscapeOutputSniff;
 
 $codeSnifferConfig = new PHP_CodeSniffer\Config(["--standard=./packages/docker/ecs-php/ruleset.xml"]);
@@ -82,7 +81,4 @@ return $configure->withRules([
   ->withConfiguredRule(BinaryOperatorSpacesFixer::class, [
     'default' => 'align',
   ])
-  // ->withConfiguredRule(GlobalVariablesOverrideSniff::class, [
-  //   'treat_files_as_scoped' => true,
-  // ])
 ;


### PR DESCRIPTION
## Description

since we have no more global variables in our `config.php` files we can reenable strict global variable override sniff.

## PR checklist

- [x] lint + lint-fix
- [x] updated/added tests
- [x] tests run locally
