### PR TITLE
set password defined in environment variable WP_PASSWORD (declared in .env) as admin password for all wp-env wp containers

### DIFF
--- a/.env
+++ b/.env
@@ -20,4 +20,5 @@ VENDOR='IONOS Group'
 
 # the ionos essentials security feature option is enabled by default so we need to use a 'safe' password from the beginning
 # otherwise playwright e2e tests would always fail since it requires a valid user
-WP_ENV_TEST_ADMIN_PASSWORD='g0lasch0815!'
+# this password will be set as the default admin password for the wp-env wp containers in after start command
+WP_PASSWORD='g0lasch0815!'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ It enables developers to maintain all of our IONOS WordPress hosting related plu
 
 # Development
 
+The default password for wp-env wordpress containers is defined in environment variable `WP_PASSWORD`. The environment variable is defined in `.env`.
+
 The repository contains all the code, configuration and tools needed to maintain our IONOS WordPress Hosting specific artifacts.
 
 The repository provides

--- a/docs/5-test.md
+++ b/docs/5-test.md
@@ -62,7 +62,7 @@ Example: `packages/wp-plugin/ionos-essentials/inc/dashboard/tests/phpunit/Accept
 
 Example: `./packages/wp-plugin/test-plugin/tests/e2e/example.spec.js`
 
-> playwright e2e tests will have a custom admin password set (in `.env` variable `WP_ENV_TEST_ADMIN_PASSWORD`) since the ionos-essentials security feature password checking requires a "safe" password to be set.
+> wp-dev containers will have a custom admin password set (in `.env` variable `WP_PASSWORD`) since the ionos-essentials security feature password checking requires a "safe" password to be set.
 
 - run e2e tests : `pnpm test:e2e`
 

--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/tabs/tools.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/tabs/tools.php
@@ -3,15 +3,13 @@
 namespace ionos\essentials\dashboard;
 
 use function ionos\essentials\is_stretch;
-
+use const ionos\essentials\PLUGIN_DIR;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION_CREDENTIALS_CHECKING;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION_DEFAULT;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION_MAIL_NOTIFY;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION_PEL;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION_XMLRPC;
-use const ionos\essentials\PLUGIN_DIR;
-
 
 ?>
  <div id="tools" class="page-section ionos-tab">

--- a/packages/wp-plugin/ionos-essentials/inc/jetpack-flow/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/jetpack-flow/index.php
@@ -109,7 +109,7 @@ const JETPACK_PLUGIN_FILE         = 'jetpack/jetpack.php';
 
   \add_action(
     'admin_page_access_denied',
-    function () : void {
+    function (): void {
       $url = add_query_arg([
         'page'   => HIDDEN_PAGE_SLUG,
         'coupon' => $_GET['coupon'],

--- a/packages/wp-plugin/ionos-essentials/inc/security/tests/e2e/security.spec.js
+++ b/packages/wp-plugin/ionos-essentials/inc/security/tests/e2e/security.spec.js
@@ -5,7 +5,7 @@ import { execTestCLI } from '../../../../../../../playwright/wp-env.js';
 test.beforeAll(async () => {
   try {
     execTestCLI(`
-      wp user update admin --user_pass='\${WP_ENV_TEST_ADMIN_PASSWORD}'
+      wp user update admin --user_pass='\${WP_PASSWORD}'
       wp user meta delete admin ionos_compromised_credentials_check_leak_detected_v2
       wp option delete IONOS_SECURITY_FEATURE_OPTION
     `);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,9 +3,6 @@ import { defineConfig, devices } from '@playwright/test';
 
 import baseConfig from '@wordpress/scripts/config/playwright.config.js';
 
-// take password from our .env file variable WP_ENV_TEST_ADMIN_PASSWORD
-process.env.WP_PASSWORD = process.env.WP_ENV_TEST_ADMIN_PASSWORD;
-
 const config = defineConfig({
   ...baseConfig,
   testMatch: 'wp-plugin/**/tests/e2e/*.spec.js',

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -127,10 +127,11 @@ EOL
 fi
 
 if [[ "${USE[@]}" =~ all|e2e ]]; then
+  # next 2 steps are required since potential runned phpunit tests rest the database to a state that is not suitable for e2e tests
   # set the default admin password to the password defined in .env file
-  pnpm -s wp-env run tests-cli wp user update admin --user_pass="${WP_ENV_TEST_ADMIN_PASSWORD}"
+  pnpm -s wp-env run tests-cli wp --quiet user update admin --user_pass="${WP_PASSWORD}"
   # reset the user meta for compromised credentials check
-  pnpm -s wp-env run tests-cli wp user meta delete admin ionos_compromised_credentials_check_leak_detected_v2 &>/dev/null || true
+  pnpm -s wp-env run tests-cli wp --quiet user meta delete admin ionos_compromised_credentials_check_leak_detected_v2 &>/dev/null || true
 
   # start wp-env e2e tests. provide part specific options and all positional arguments that are php files
   (

--- a/scripts/wp-env-after-start.sh
+++ b/scripts/wp-env-after-start.sh
@@ -225,6 +225,11 @@ for prefix in 'cli-1' 'tests-cli-1' ; do
 
     wp --quiet option update WPLANG 'en_US'
 
+    # set the default admin password to the password defined in .env file
+    wp --quiet user update admin --user_pass="${WP_PASSWORD}"
+    # reset the user meta for compromised credentials check (in case of wp-env restart)
+    wp --quiet user meta delete admin ionos_compromised_credentials_check_leak_detected_v2 &>/dev/null || true
+
     # fix permissions for mu-plugins folder if any
     # (leaving the permisions as-is will result in an error on destroy restart wp-env)
     if find /var/www/html/wp-content/mu-plugins -mindepth 1 -maxdepth 1 -type d -printf '%f\n' &>/dev/null; then


### PR DESCRIPTION
## PR checklist

- [x] lint + lint-fix
- [x] tests run locally
- [x] updated the documentation if necessary

