### PR TITLE
chore(lint): no yoda conditions

### DIFF
--- a/packages/docker/ecs-php/ecs-config.php
+++ b/packages/docker/ecs-php/ecs-config.php
@@ -49,7 +49,8 @@ return $configure->withRules([
       '*/docs/packages/*',
       '**/ecs-config.php',
       '**/rector-config-php7.4.php',
-      '**/rector-fix-types.php'
+      '**/rector-fix-types.php',
+      YodaStyleFixer::class
     ]
   )
   ->withPreparedSets(
@@ -71,12 +72,6 @@ return $configure->withRules([
   // ->withEditorConfig(true)
   // use 2 spaces instead of psr12 default (4 spaces)
   ->withSpacing(indentation: '  ')
-
-  ->withConfiguredRule(YodaStyleFixer::class, [
-    'equal' => true,
-    'identical' => true,
-    'less_and_greater' => true,
-  ])
   // align assoc arrays
   ->withConfiguredRule(BinaryOperatorSpacesFixer::class, [
     'default' => 'align',

--- a/packages/docker/ecs-php/ruleset.xml
+++ b/packages/docker/ecs-php/ruleset.xml
@@ -56,6 +56,7 @@
     <exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
     <exclude name="PSR2.ControlStructures.SwitchDeclaration"/>
     <exclude name="PSR12.Files.FileHeader"/>
+    <exclude name="WordPress.PHP.YodaConditions"/>
   </rule>
 
   <!-- <rule ref="WordPress-Core">


### PR DESCRIPTION
## Description

yoda or not - both options are valid and neither is preferred by lint or lint-fix