### PR TITLE
fix: add early return after_disable_xmlrpc_methods

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/security/xmlrpc.php
+++ b/packages/wp-plugin/ionos-essentials/inc/security/xmlrpc.php
@@ -50,6 +50,7 @@ function _disable_xmlrpc_methods()
 
   if (! isset($_SERVER['REMOTE_ADDR'])) {
     _disable_xmlrpc_methods();
+    return;
   }
 
   $ip = $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
## Description

skips running ip4 and ip6 tests if xmlrpc methods are already disabled.

## PR checklist

- [x] lint + lint-fix
- [x] tests run locally
