### PR TITLE
fix(essentials): replace array_all for more compatibility

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/next-best-actions/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/next-best-actions/index.php
@@ -6,7 +6,7 @@ function render_callback()
 {
   require_once __DIR__ . '/class-nba.php';
   $actions = NBA::get_actions();
-  if (empty($actions) || array_all($actions, fn (NBA $action) => ! $action->active)) {
+  if (empty($actions) || count(array_filter($actions, fn (NBA $action) => $action->active)) === 0) {
     return;
   }
 


### PR DESCRIPTION
## Description

fixes an error when php and wordpress version are too old. found the bug on stretch monster space with an older wordpress version, that doesnt have the polyfill for the php function.

## PR checklist

- [ ] lint + lint-fix
- [ ] updated/added tests
- [ ] tests run locally
- [ ] updated the documentation if necessary

## [optional] QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

_If the ui was changed by PR please provide a before and after screenshot_
