### PR TITLE
do not show HTML-Tags on page

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/descriptify/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/descriptify/index.php
@@ -60,7 +60,7 @@ add_action(
         ( function () {
             const description = document.createElement('p');
             description.className = 'description';
-            description.innerHTML = '<?php echo \esc_js(addslashes($website_url_description)); ?>';
+            description.innerHTML = '<?php printf(addslashes($website_url_description)); ?>';
 
             document.getElementById( 'siteurl' )?.parentNode.appendChild( description.cloneNode( true ) );
             document.getElementById( 'home' )?.parentNode.appendChild( description.cloneNode( true ) );


### PR DESCRIPTION
without that fix, HTML-Tags are print out, not the real link

issue was introduced may, 8th: https://github.com/IONOS-WordPress/ionos-wordpress/pull/317