### PR TITLE
fix: ensure password fields are not empty before comparison

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/security/credentials-checking.php
+++ b/packages/wp-plugin/ionos-essentials/inc/security/credentials-checking.php
@@ -13,7 +13,7 @@ if (! defined('ABSPATH')) {
 \add_action(
   hook_name: 'check_passwords',
   callback: function ($user_login, $pass1, $pass2) {
-    if ($pass1 !== $pass2) {
+    if (empty($pass1) || $pass1 !== $pass2) {
       return;
     }
 


### PR DESCRIPTION
while changing personal user settings, a password check is performed. if the password is unchanged, it es empty, which results in "leaked". 

With that fix, the user can change his or her settings again, regardless of the password.