### PR TITLE
Improve last scan display logic and messaging in WPScan

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/vulnerability/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/vulnerability/index.php
@@ -82,9 +82,7 @@ function display_full_report_link($args)
 
 function display_last_scan($args)
 {
-  if (! $args['last_scan']) {
-    \esc_html_e('No scan has been performed yet.', 'ionos-essentials');
-  } else {
-    echo \esc_html(sprintf('Last scan ran %s ago', $args['last_scan']));
-  }
+  echo (! $args['last_scan']) ? \esc_html('No scan has been performed yet.', 'ionos-essentials') : \esc_html(
+    sprintf('Last scan ran %s ago', $args['last_scan'])
+  );
 }

--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/vulnerability/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/vulnerability/index.php
@@ -82,11 +82,9 @@ function display_full_report_link($args)
 
 function display_last_scan($args)
 {
-  echo \esc_html__('Last scan', 'ionos-essentials');
-  echo ': ';
-  printf(
-    // translators: %s is replaced with the time since the last scan
-    \esc_html__('%s ago', 'ionos-essentials'),
-    \esc_attr($args['last_scan'])
-  );
+  if (! $args['last_scan']) {
+    \esc_html_e('No scan has been performed yet.', 'ionos-essentials');
+  } else {
+    echo \esc_html(sprintf('Last scan ran %s ago', $args['last_scan']));
+  }
 }

--- a/packages/wp-plugin/ionos-essentials/inc/wpscan/controller/class-wpscan.php
+++ b/packages/wp-plugin/ionos-essentials/inc/wpscan/controller/class-wpscan.php
@@ -221,7 +221,7 @@ class WPScan
   {
     $last_run = \get_transient('ionos_wpscan_last_scan');
     if (false === $last_run) {
-      return \__('No scan has been performed yet.', 'ionos-essentials');
+      return false;
     }
     return human_time_diff($last_run, time());
   }

--- a/packages/wp-plugin/ionos-essentials/inc/wpscan/views/summary.php
+++ b/packages/wp-plugin/ionos-essentials/inc/wpscan/views/summary.php
@@ -44,7 +44,10 @@ function summary()
 
           <p class="paragraph paragraph--neutral">
             <?php
-    echo \esc_html(sprintf('Last scan ran %s ago', $wpscan->get_lastscan()));
+            $last_scan = $wpscan->get_lastscan();
+  echo (! $last_scan) ? \esc_html('No scan has been performed yet.', 'ionos-essentials') : \esc_html(
+    sprintf('Last scan ran %s ago', $last_scan)
+  );
   ?>
           </p>
         </div>


### PR DESCRIPTION
bei der gelegenheit habe ich die Nachricht angepasst:
bisher stand im overview tab und im tools tab ein unterschiedlicher text 
jetzt steht da genau das gleiche

das ding ist gelint-fixed, die weirden einrückungen kommen vom linter