### PR TITLE
if plugin not found, pass

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/wpscan/controller/class-wpscan.php
+++ b/packages/wp-plugin/ionos-essentials/inc/wpscan/controller/class-wpscan.php
@@ -284,7 +284,7 @@ class WPScan
     }
     $data         = $middleware->convert_middleware_data($data);
 
-    $next_run = (strpos(json_encode($data), 'UNKNOWN')) ? 5 * MINUTE_IN_SECONDS : 6 * HOUR_IN_SECONDS;
+    $next_run = (strpos(json_encode($data), 'UNKNOWN')) ? 5 * MINUTE_IN_SECONDS : 23 * HOUR_IN_SECONDS;
 
     \set_transient('ionos_wpscan_last_scan', time(), $next_run);
     \set_transient('ionos_wpscan_issues', $data, $next_run);

--- a/packages/wp-plugin/ionos-essentials/inc/wpscan/controller/class-wpscanmiddleware.php
+++ b/packages/wp-plugin/ionos-essentials/inc/wpscan/controller/class-wpscanmiddleware.php
@@ -35,6 +35,9 @@ class WPScanMiddleware
     }
 
     $status_code = \wp_remote_retrieve_response_code($response);
+    if (404 === $status_code) {
+      return 'nothing_found';
+    }
     if (200 !== $status_code) {
       error_log('WPScan middleware error statuscode: ' . \wp_remote_retrieve_response_message($response));
       return false;


### PR DESCRIPTION
if middleware says: plugin not found (that is with all plugins not checked by wpscan, that come from a third party source), resonse is: "Go ahead, install"