### PR TITLE
Feature/gphwpp 4040 fix margin

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/next-best-actions/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/blocks/next-best-actions/index.php
@@ -64,17 +64,17 @@ function render_callback(): void
   }
 
   ?>
-
+      <div class="card ionos_next_best_actions">
         <div class="headline"><?php \esc_html_e("Unlock Your Website's Potential", 'ionos-essentials'); ?></div>
         <div class="paragraph"><?php \esc_html_e(
           'Your website is live, but your journey is just beginning. Explore the recommended next actions to drive growth, improve performance, and achieve your online goals.',
           'ionos-essentials'
         ); ?></div>
 
-      <div class="grid">
-        <?php echo \wp_kses($cards, 'post'); ?>
+        <div class="grid">
+          <?php echo \wp_kses($cards, 'post'); ?>
+        </div>
       </div>
-
   <?php
 }
 

--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/dashboard.css
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/dashboard.css
@@ -102,8 +102,7 @@ main{
 
 .ionos_next_best_actions{
   background: white;
-  padding-top: 2em;
-  margin: 0 15px 2em;
+  padding: 2em 15px;
 
   .card{
     background: rgb(244, 247, 250);

--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/tabs/overview.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/tabs/overview.php
@@ -11,7 +11,7 @@ defined('ABSPATH') || exit();
       There must be no whitespace or newline within the .grid-col elements, as this would display even an empty cell,
       but empty cells should not be displayed (see)
     -->
-    <div class="card grid-col grid-col--12 ionos_next_best_actions"><?php blocks\next_best_actions\render_callback(); ?></div>
+    <div class="grid-col grid-col--12"><?php blocks\next_best_actions\render_callback(); ?></div>
     <div class="grid-col grid-col--4 grid-col--small-12"><?php blocks\vulnerability\render_callback(); ?></div>
     <div class="grid-col grid-col--8 grid-col--small-12"><?php blocks\quick_links\render_callback(); ?></div>
     <div class="grid-col grid-col--7 grid-col--medium-6 grid-col--small-12"><?php blocks\my_account\render_callback(); ?></div>


### PR DESCRIPTION
## Description

- fixed margin on the right side of the NBA block
- fixed margin of whole content when in mobile-view
- fixed border-radius for NBA block

## PR checklist

- [x] lint + lint-fix
- [ ] updated/added tests
- [ ] tests run locally
- [ ] updated the documentation if necessary

## [optional] QA Instructions, Screenshots, Recordings

**before**:
<img width="349" height="308" alt="Bildschirmfoto 2025-08-13 um 17 23 09" src="https://github.com/user-attachments/assets/dae82b89-4b26-475d-8ee1-c024ae710a60" />
<img width="498" height="596" alt="Bildschirmfoto 2025-08-13 um 17 23 03" src="https://github.com/user-attachments/assets/ed27867e-6778-4089-a859-2a3289bc716f" />
<img width="1296" height="720" alt="Bildschirmfoto 2025-08-14 um 10 41 07" src="https://github.com/user-attachments/assets/bef457f7-c2dd-437a-9ae1-b66f6469ea57" />



**after**:
<img width="499" height="412" alt="Bildschirmfoto 2025-08-13 um 17 22 42" src="https://github.com/user-attachments/assets/c36c9433-174d-4436-9d9c-1f80b1001782" />
<img width="502" height="600" alt="Bildschirmfoto 2025-08-13 um 17 22 50" src="https://github.com/user-attachments/assets/0c70d68c-7f8b-475a-82cd-ff2f40eccb6e" />
<img width="1284" height="708" alt="Bildschirmfoto 2025-08-14 um 10 42 26" src="https://github.com/user-attachments/assets/1de79cd0-8a5b-48a5-88d6-d4e0f3ed96cb" />
