### PR TITLE
update info.json

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -138,6 +138,8 @@ EOF
     SLUG="${PLUGIN}/${PLUGIN}.php"
     # example: https://github.com/lgersman/ionos-wordpress/releases/download/%40ionos-wordpress%2Fessentials%400.1.3/ionos-essentials-0.1.3-php7.4.zip
     PACKAGE="https://github.com/$GITHUB_OWNER_REPO/releases/download/$(printf $PRE_RELEASE | jq -Rrs '@uri')/$ASSET"
+
+    LAST_UPDATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     # CHANGELOG is the release note of the pre-release (aka the changelog markdown of the release)
     CHANGELOG="$(gh release view $PRE_RELEASE --json body --jq '.body')"
 
@@ -150,8 +152,9 @@ EOF
       --arg version "$VERSION" \
       --arg slug "$SLUG" \
       --arg package "$PACKAGE" \
+      --arg last_updated "$LAST_UPDATED" \
       --arg changelog "$CHANGELOG_HTML" \
-      '{version: $version, slug: $slug, package: $package, sections : { changelog: $changelog }}' > "$INFO_JSON_FILENAME"
+      '{version: $version, slug: $slug, package: $package, last_updated: $last_updated, sections : { changelog: $changelog }}' > "$INFO_JSON_FILENAME"
 
     if ! gh release upload $LATEST_RELEASE_TAG $INFO_JSON_FILENAME --clobber; then
       $error_message="Failed to upload asset $INFO_JSON_FILENAME"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -154,7 +154,7 @@ EOF
       --arg package "$PACKAGE" \
       --arg last_updated "$LAST_UPDATED" \
       --arg changelog "$CHANGELOG_HTML" \
-      '{version: $version, slug: $slug, package: $package, last_updated: $last_updated, sections : { changelog: $changelog }}' > "$INFO_JSON_FILENAME"
+      '{version: $version, slug: $slug, package: $package, last_updated: $last_updated, requires_wp: "6.0", sections : { changelog: $changelog }}' > "$INFO_JSON_FILENAME"
 
     if ! gh release upload $LATEST_RELEASE_TAG $INFO_JSON_FILENAME --clobber; then
       $error_message="Failed to upload asset $INFO_JSON_FILENAME"


### PR DESCRIPTION
- Add a line to the info.json, when the plugin was last updated. This should change the "4 years ago" from the screenshot below
- add a line, which wordpress version is required

Ticket: https://hosting-jira.1and1.org/browse/GPHWPP-4021
<img width="592" height="338" alt="image" src="https://github.com/user-attachments/assets/10f9620b-1a98-4ff6-80a3-271bc81a307c" />

