### PR TITLE
feat(dashboard): redirect to correct dashboard on login

### DIFF
--- a/packages/wp-plugin/ionos-essentials/inc/dashboard/index.php
+++ b/packages/wp-plugin/ionos-essentials/inc/dashboard/index.php
@@ -92,6 +92,20 @@ if (\get_option('ionos_essentials_dashboard_mode', true)) {
   });
 }
 
+\add_filter('login_redirect', function ($redirect_to, $requested_redirect_to, $user) {
+  // early return if not a valid wp user
+  if (! $user instanceof \WP_User) {
+    return $redirect_to;
+  }
+  if ($requested_redirect_to !== '') {
+    return $requested_redirect_to;
+  }
+  if (\get_option('ionos_essentials_dashboard_mode', true)) {
+    return \menu_page_url(ADMIN_PAGE_SLUG, false);
+  }
+  return \get_admin_url();
+}, 100, 3);
+
 // fixes the displayed page title for our custom admin page.
 \add_filter(
   hook_name: 'admin_title',


### PR DESCRIPTION
## Description

Improvements to the dashboard redirect.
-> dont expect a redirect to wp-admin after login, but directly redirect to our dashboard if the setting is true

## PR checklist

- [ ] lint + lint-fix
- [ ] updated/added tests
- [ ] tests run locally
- [ ] updated the documentation if necessary

## [optional] QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

_If the ui was changed by PR please provide a before and after screenshot_
