### PR TITLE
Fix/dashboard helpcenter

### DIFF
--- a/packages/wp-plugin/ionos-essentials/ionos-essentials.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials.php
@@ -52,6 +52,7 @@ require_once __DIR__ . '/ionos-essentials/inc/login/index.php';
 require_once __DIR__ . '/ionos-essentials/inc/security/index.php';
 require_once __DIR__ . '/ionos-essentials/inc/maintenance_mode/index.php';
 require_once __DIR__ . '/ionos-essentials/inc/wpscan/index.php';
+require_once __DIR__ . '/ionos-essentials/inc/extendify/index.php';
 
 // soc plugin components
 require_once __DIR__ . '/ionos-essentials/inc/migration/index.php';

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/dashboard.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/dashboard.js
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     dashboard.querySelector(`[data-tab="${hash}"]`)?.click();
 
-    document.querySelector('li.current')?.classList.remove('current')
+    document.querySelector('li.current')?.classList.remove('current');
     const selector = `admin.php?page=${wpData.tenant}` + (hash === 'overview' ? '' : `#${hash}`);
     document.querySelector(`#adminmenu .wp-submenu a[href="${selector}"]`).parentElement.classList.add('current');
   }
@@ -84,7 +84,7 @@ document.addEventListener('DOMContentLoaded', function () {
     };
   }
 
-  const helpCenterLink = document.querySelector('a[data-nba-id="help-center"]');
+  const helpCenterLink = dashboard.querySelector('a[data-nba-id="help-center"]');
   if (helpCenterLink) {
     helpCenterLink.onclick = () => {
       document.querySelector('.extendify-help-center button').click();

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/extendify/index.css
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/extendify/index.css
@@ -1,0 +1,7 @@
+/*
+  disable "Site Assistant" tour in extendify helpcenter / tours
+  since it breaks access to the admin dashboard
+*/
+.extendify-help-center *[data-extendify-tour-id="site-assistant-tour"] {
+  display: none;
+}

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/extendify/index.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/extendify/index.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ionos\essentials\extendify;
+
+defined('ABSPATH') || exit();
+
+\add_action('admin_enqueue_scripts', function() {
+  \wp_enqueue_style(
+    'ionos-extendify',
+    \plugin_dir_url(__FILE__) . 'index.css',
+    [],
+    filemtime(\plugin_dir_path(__FILE__) . 'index.css')
+  );
+});

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/README.md
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/README.md
@@ -6,6 +6,8 @@ shows instead of extendify-launch page
 
 to recreate extendify setup run:
 
-wp plugin install https://web-hosting.s3-eu-central-1.ionoscloud.com/extendify/01-ext-ion2hs971.zip --force --activate --allow-root
-wp plugin install extendify --activate --allow-root
-wp theme install extendable --activate --allow-root
+```
+pnpm wp-env run cli wp plugin install https://web-hosting.s3-eu-central-1.ionoscloud.com/extendify/01-ext-ion2hs971.zip --force --activate
+pnpm wp-env run cli wp plugin install extendify --activate
+pnpm wp-env run cli wp theme install extendable --activate
+```

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -70,7 +70,6 @@ if [[ "${USE[@]}" =~ e2e|react|all ]]; then
   fi
 
   # execute playwright browser installation if not already done
-  # [[ $(find ~/.cache/ms-playwright -path "*/chrome-linux/chrome" 2>/dev/null | wc -l) -eq "0" ]] && pnpm exec playwright install chromium
   pnpm exec playwright install chromium
 fi
 


### PR DESCRIPTION
## Description

some minor dashboard fixes

## PR checklist

- [x] lint + lint-fix
- [x] tests run locally
- [x] updated the documentation if necessary

## [optional] QA Instructions, Screenshots, Recordings

1. open extendify help center tour
  - select tours
  - the "Site Assistant Tour" is not visible

2. click nba action "Discover Help Center"
  - the extendify site assistant should be appear and the nba action should disappear