### PR TITLE
Feature/gphwpp 4107 show feedback btn only when dismissed

### DIFF
--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/blocks/next-best-actions/views/all-done.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/blocks/next-best-actions/views/all-done.php
@@ -8,6 +8,7 @@ use const ionos\essentials\PLUGIN_FILE;
 
 function all_done_view(): void
 {
+    $dismissed = \get_option('ionos_nba_status')['survey']['dismissed'] ?? false;
   ?>
   <div id="ionos_next_best_actions__all_done">
    <div class="container">
@@ -25,7 +26,9 @@ function all_done_view(): void
     <?php if ('ionos' === Tenant::get_slug()) { ?>
       <div class="buttons">
         <a href="#" class="button button--secondary"><?php echo esc_html__('View IONOS Help Center', 'ionos-essentials')?></a>
+        <?php if ( $dismissed ) { ?>
         <a href="#" class="button button--secondary"><?php echo esc_html__('Leave feedback', 'ionos-essentials')?></a>
+        <?php } ?>
       </div>
     <?php } ?>
    </div>


### PR DESCRIPTION
## Description

add something here if branch name + PR title are not self-explanatory

## Checklist

- [x] Acceptance Criteria are fulfilled (or there is no ticket)
- [x] tests added if necessary
- [x] docs added if necessary

## Screenshots / Recordings

_If the ui was changed by PR please provide a screenshot_

## manual testing

- [ ] done / trivial change (docs, ...)
- [x] requested

please, check if **leave feedback** button is shown, when take the survey action was dismissed.
and check if **leave feedback** button is NOT shown, when take the survey action primary button was clicked.

## Reviewer checklist

- [ ] if requested manual testing done
- [ ] sufficient tests
- [ ] sufficient docs
- [ ] general Code Review
