### PR TITLE
stretch-extra maintenance feature: pick maintenance translations from wordpress

### DIFF
--- a/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/maintenance/maintenance.php
+++ b/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/maintenance/maintenance.php
@@ -57,8 +57,8 @@ if (PHP_SAPI === 'cli') {
 
     // Default fallback: 503 with Retry-After header
     \wp_die(
-      message: \__('Briefly unavailable for scheduled maintenance. Check back in a minute.', 'stretch-extra'),
-      title: \__('Maintenance', 'stretch-extra'),
+      message: \__('Briefly unavailable for scheduled maintenance. Check back in a minute.'),
+      title: \__('Maintenance'),
       args: [
         'response'           => 503,
         'additional_headers' => [


### PR DESCRIPTION
## Description

Since we mimick the same maintenance L&F as WordPress we can use the same translations provided by WordPress (=> and do'nt need to maintain the same translation by ourself).

## Checklist

- [x] Acceptance Criteria are fulfilled (or there is no ticket)
- [x] tests added if necessary
- [x] docs added if necessary

## manual testing

- [x] done / trivial change (docs, ...)
- [ ] requested
      _Please replace this line with instructions on how to test your changes_

## Reviewer checklist

- [x] if requested manual testing done
- [x] sufficient tests
- [x] sufficient docs
- [x] general Code Review
