### PR TITLE
tests(ionos-essentials): add beforeAll to avoid overlapping dialogs

### DIFF
--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/security-options.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/security-options.spec.js
@@ -8,7 +8,17 @@ test.describe(
   },
   () => {
     test.beforeAll(async () => {
-      execTestCLI(`wp --quiet option delete IONOS_SECURITY_FEATURE_OPTION`);
+      execTestCLI(`
+        # set popup after timestamp to a far future date to prevent popups during e2e tests
+        wp --quiet user meta update 1 ionos_popup_after_timestamp ${Math.MAX_SAFE_INTEGER}
+        # set essentials welcome overlay already clicked away
+        wp --quiet user meta update 1 ionos_essentials_welcome true
+        # simulate extendify onboarding already done
+        wp --quiet option update extendify_attempted_redirect_count 4
+        
+        # test specific
+        wp --quiet option delete IONOS_SECURITY_FEATURE_OPTION
+        `);
     });
 
     test('user can set option', async ({ admin, page }) => {

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/tabs.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/tabs.spec.js
@@ -1,6 +1,18 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { execTestCLI } from '../../../../../../../../playwright/wp-env';
 
 test.describe('Tabs', () => {
+  test.beforeAll(async () => {
+    execTestCLI(`
+          # set popup after timestamp to a far future date to prevent popups during e2e tests
+          wp --quiet user meta update 1 ionos_popup_after_timestamp ${Math.MAX_SAFE_INTEGER}
+          # set essentials welcome overlay already clicked away
+          wp --quiet user meta update 1 ionos_essentials_welcome true
+          # simulate extendify onboarding already done
+          wp --quiet option update extendify_attempted_redirect_count 4
+        `);
+  });
+
   test('user can switch between tabs', async ({ admin, page }) => {
     await admin.visitAdminPage('/');
 


### PR DESCRIPTION
## Checklist

- [x] Acceptance Criteria are fulfilled (or there is no ticket)
- [x] tests added if necessary
- [x] docs added if necessary

## manual testing

- [x] done / trivial change (docs, ...)
- [ ] requested
      _Please replace this line with instructions on how to test your changes_

## Reviewer checklist

- [x] if requested manual testing done
- [x] sufficient tests
- [x] sufficient docs
- [x] general Code Review
