### PR TITLE
chore: increase lint memory limit

### DIFF
--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-de_DE.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-de_DE.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: de\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-04-09 14:29+0200\n"
-"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: ionos-wordpress/essentials 0.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
+"PO-Revision-Date: 2025-04-09 14:29+0200\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: Poedit 3.6\n"
 
@@ -827,10 +827,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Erfahren Sie mehr über SSL und wie Sie es aktivieren."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Update"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Löschen"
 
@@ -1118,3 +1120,7 @@ msgstr "Sicher"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Unsicher"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-en_US.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-en_US.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: en_US\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-01-07T11:44:38+00:00\n"
-"POT-Creation-Date: 2025-01-07T11:44:38+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: ionos-wordpress/essentials 0.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-01-07T11:44:38+00:00\n"
+"PO-Revision-Date: 2025-01-07T11:44:38+00:00\n"
+"Language: en_US\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: WP-CLI 2.10.0\n"
 
@@ -827,10 +827,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Learn more about SSL and how to activate it."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Update"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Delete"
 
@@ -1118,3 +1120,7 @@ msgstr "Secure"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Insecure"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-es_ES.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-es_ES.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: es\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-04-09 07:46+0200\n"
-"POT-Creation-Date: 2025-02-05T09:50:40+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: ionos-wordpress/essentials 0.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-05T09:50:40+00:00\n"
+"PO-Revision-Date: 2025-04-09 07:46+0200\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: Poedit 3.6\n"
 
@@ -827,10 +827,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Más información sobre SSL y cómo activarlo."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Actualización"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Borrar"
 
@@ -1118,3 +1120,7 @@ msgstr "Seguro"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "No seguro"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-es_MX.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-es_MX.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: es_MX\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-08-05 22:39+0200\n"
-"POT-Creation-Date: 2025-04-09T08:51:38+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: ionos-essentials 0.2.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-04-09T08:51:38+00:00\n"
+"PO-Revision-Date: 2025-08-05 22:39+0200\n"
+"Language: es_MX\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: Poedit 3.6\n"
 
@@ -827,10 +827,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Más información sobre SSL y cómo activarlo."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Actualización"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Borrar"
 
@@ -1118,3 +1120,7 @@ msgstr "Seguro"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "No seguro"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-fr_FR.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-fr_FR.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: fr\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-04-15 10:33+0200\n"
-"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Project-Id-Version: ionos-wordpress/essentials 0.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
+"PO-Revision-Date: 2025-04-15 10:33+0200\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: Poedit 3.6\n"
 
@@ -827,10 +827,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "En savoir plus sur SSL et comment l'activer."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Mettre à jour"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1121,3 +1123,7 @@ msgstr "Sécurisé"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Non sécurisé"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-it_IT.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-it_IT.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: it\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-04-14 14:15+0200\n"
-"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: ionos-wordpress/essentials 0.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
+"PO-Revision-Date: 2025-04-14 14:15+0200\n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: Poedit 3.6\n"
 
@@ -827,10 +827,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Per saperne di più sull'SSL e su come attivarlo."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Aggiorna"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Elimina"
 
@@ -1119,3 +1121,7 @@ msgstr "Sicuro"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Insicuro"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-nl_NL.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-nl_NL.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: nl\n"
-"Language-Team: Dutch\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-09-23 09:18\n"
-"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: 75e86f746860bcef4fdd142a24cf2467\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Dutch\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
+"PO-Revision-Date: 2025-09-23 09:18\n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Crowdin-File: LOC-8516_ionos-essentials-nl_NL (6).po\n"
 "X-Crowdin-File-ID: 536\n"
 "X-Crowdin-Language: nl\n"
@@ -832,10 +832,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Meer informatie over SSL en hoe je dit activeert."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Update"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Verwijder"
 
@@ -1123,3 +1125,7 @@ msgstr "Veilig"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Onveilig"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-pl_PL.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-pl_PL.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ionos-wordpress/essentials 0.0.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
-"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
-"PO-Revision-Date: 2026-02-19 10:37+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
-"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
+"PO-Revision-Date: 2026-02-19 10:37+0100\n"
+"Language: pl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: ionos-essentials\n"
 "X-Generator: Poedit 3.7\n"
@@ -949,6 +949,7 @@ msgid "View update details"
 msgstr "Zobacz szczegóły aktualizacji"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Aktualizuj"
 
@@ -957,6 +958,7 @@ msgid "This theme is active. Please activate another theme."
 msgstr "Ten motyw jest aktywny. Proszę aktywuj inny motyw."
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Usuń"
 
@@ -1118,3 +1120,7 @@ msgstr "Aktywny"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Nieaktywny"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-sv_SE.po
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials-sv_SE.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: sv\n"
-"Language-Team: Swedish\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2025-09-23 09:19\n"
-"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Project-Id-Version: 75e86f746860bcef4fdd142a24cf2467\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Swedish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-19T08:22:27+00:00\n"
+"PO-Revision-Date: 2025-09-23 09:19\n"
+"Language: sv\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Crowdin-File: LOC-8516_ionos-essentials-sv_SE (4).po\n"
 "X-Crowdin-File-ID: 534\n"
 "X-Crowdin-Language: sv\n"
@@ -832,10 +832,12 @@ msgid "Learn more about SSL and how to activate it."
 msgstr "Meer informatie over SSL en hoe je dit activeert"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr "Uppdatera"
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr "Radera"
 
@@ -1123,3 +1125,7 @@ msgstr "Säker"
 #: ionos-essentials/inc/dashboard/blocks/site-health/index.php
 msgid "Insecure"
 msgstr "Osäker"
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "Install"
+msgstr ""

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials.pot
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/languages/ionos-essentials.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Essentials 1.4.5\n"
+"Project-Id-Version: Essentials 1.4.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/html\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-02-13T12:03:48+00:00\n"
+"POT-Creation-Date: 2026-03-31T10:20:14+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: ionos-essentials\n"
@@ -1017,6 +1017,7 @@ msgid "View update details"
 msgstr ""
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Update"
 msgstr ""
 
@@ -1025,6 +1026,7 @@ msgid "This theme is active. Please activate another theme."
 msgstr ""
 
 #: ionos-essentials/inc/wpscan/views/issues.php
+#: ionos-essentials/build/dashboard/index.js
 msgid "Delete"
 msgstr ""
 
@@ -1041,7 +1043,7 @@ msgid "Installing..."
 msgstr ""
 
 #: ionos-essentials/build/dashboard/index.js
-msgid "An error occured while enabling WordPress MCP."
+msgid "Install"
 msgstr ""
 
 #: ionos-essentials/build/dashboard/index.js
@@ -1050,6 +1052,10 @@ msgstr ""
 
 #: ionos-essentials/build/dashboard/index.js
 msgid "WordPress MCP enabled"
+msgstr ""
+
+#: ionos-essentials/build/dashboard/index.js
+msgid "An error occured while enabling WordPress MCP."
 msgstr ""
 
 #: ionos-essentials/build/dashboard/index.js

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -100,7 +100,7 @@ function ionos.wordpress.ecs() {
     ionos-wordpress/ecs-php \
     check \
       $([[ "$FIX" == 'yes' ]] && echo -n "--fix" ||:) \
-      --no-diffs --clear-cache --config ./packages/docker/ecs-php/ecs-config.php --no-progress-bar \
+      --no-diffs --clear-cache --config ./packages/docker/ecs-php/ecs-config.php --no-progress-bar --memory-limit=1G \
       ${POSITIONAL_ARGS[@]}
 }
 


### PR DESCRIPTION
## Description

encountered the following error:
```
lint-fix php files files with ecs ...

Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 8192 bytes) in /composer/vendor/symplify/easy-coding-standard/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php on line 78
```

fix was to increase memory limit