### PR TITLE
Hotfix for switch page: revert changes

### DIFF
--- a/.changeset/deep-owls-write.md
+++ b/.changeset/deep-owls-write.md
@@ -1,0 +1,5 @@
+---
+'@ionos-wordpress/essentials': patch
+---
+
+hotfix for ai switch-page

--- a/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/secondary-theme-dir.php
+++ b/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/secondary-theme-dir.php
@@ -84,7 +84,7 @@ const IONOS_CUSTOM_DELETED_THEMES_OPTION = 'IONOS_CUSTOM_DELETED_THEMES_OPTION';
 defined('WP_CLI') || \add_action('muplugins_loaded', function () {
   $is_initialized = \get_option('stretch_extra_extendable_theme_dir_initialized', false) || \get_option(
     'stylesheet'
-  ) === 'extendable'  && \get_option('template') === 'extendable';
+  ) === 'extendable';
   if ($is_initialized !== false) {
     return;
   }

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/index.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/index.php
@@ -16,7 +16,6 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
 use const ionos\essentials\dashboard\blocks\next_best_actions\OPTION_IONOS_ESSENTIALS_NBA_SETUP_COMPLETED;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION;
 use const ionos\essentials\security\IONOS_SECURITY_FEATURE_OPTION_DEFAULT;
-use const ionos\essentials\switch_page\IONOS_ONBOARDING_OPTION;
 
 const REQUIRED_USER_CAPABILITIES = 'read';
 
@@ -24,14 +23,6 @@ const REQUIRED_USER_CAPABILITIES = 'read';
   define('IONOS_ESSENTIALS_DASHBOARD_ADMIN_PAGE_TITLE', Tenant::get_label());
   define('ADMIN_PAGE_SLUG', Tenant::get_slug());
   define('ADMIN_PAGE_HOOK', 'toplevel_page_' . ADMIN_PAGE_SLUG);
-
-  // redirect to onboarding if dashboard is accessed but onboarding is not completed yet
-  \add_action('load-' . ADMIN_PAGE_HOOK, function () {
-    if (! get_option(IONOS_ONBOARDING_OPTION)) {
-      \wp_safe_redirect(\admin_url('admin.php?page=' . Tenant::get_slug() . '-onboarding'));
-      exit;
-    }
-  });
 });
 
 \add_action('admin_menu', function () {
@@ -87,21 +78,20 @@ const REQUIRED_USER_CAPABILITIES = 'read';
 
 // we want to be presented as "default page" in wp-admin
 // redirect to our custom dashboard page if /wp-admin/ is requested
-\add_action('load-index.php', function () {
-  if (! get_option(IONOS_ONBOARDING_OPTION)) {
-    \wp_safe_redirect(\admin_url('admin.php?page=' . Tenant::get_slug() . '-onboarding'));
-    exit;
-  }
-  if (\get_option('ionos_essentials_dashboard_mode', true) && \current_user_can(REQUIRED_USER_CAPABILITIES)) {
-    $current_url = \home_url($_SERVER['REQUEST_URI']);
-    $admin_url   = \get_admin_url();
+if (\get_option('ionos_essentials_dashboard_mode', true)) {
+  \add_action('load-index.php', function () {
+    if (\current_user_can(REQUIRED_USER_CAPABILITIES)) {
+      $current_url = \home_url($_SERVER['REQUEST_URI']);
+      $admin_url   = \get_admin_url();
 
-    if ($current_url === $admin_url) {
+      if ($current_url !== $admin_url) { // only redirect if we are on empty /wp-admin/
+        return;
+      }
+
       \wp_safe_redirect(\menu_page_url(ADMIN_PAGE_SLUG, false));
-      exit;
     }
-  }
-});
+  });
+}
 
 // fixes the displayed page title for our custom admin page.
 \add_filter(

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tabs/tools.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tabs/tools.php
@@ -217,7 +217,7 @@ render_section([
           </section>
           <?php include_once(ABSPATH . 'wp-admin/includes/plugin.php');
 
-$_plugin = _is_plugin_active('01-ext-ion8dhas7/01-ext-ion8dhas7.php') || _is_plugin_active('01-ext-ion8dhas7-stretch/01-ext-ion8dhas7-stretch.php');
+$_plugin = _is_plugin_active('01-ext-ion8dhas7/01-ext-ion8dhas7.php');
 
 $match = array_filter(array_keys(get_plugins()), fn ($k) => str_starts_with($k, '01-ext-'));
 

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/dashboard-localization.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/dashboard-localization.spec.js
@@ -8,10 +8,7 @@ test.describe(
   },
   () => {
     test('/dashboard uses wp-admin language', async ({ admin, page }) => {
-      execTestCLI(`wp --quiet user meta delete 1 ionos_essentials_welcome || true
-        # simulate switch page decision
-        wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy
-        `);
+      execTestCLI(`wp --quiet user meta delete 1 ionos_essentials_welcome || true`);
 
       const targetLanguageName = 'de_DE';
 

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/dashboard-myaccount.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/dashboard-myaccount.spec.js
@@ -8,11 +8,7 @@ test.describe(
   },
   () => {
     test('/dashboard contains My Account block', async ({ admin, page }) => {
-      execTestCLI(`
-        wp --quiet option update ionos_group_brand ionos
-        # simulate switch page decision
-        wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy
-        `);
+      execTestCLI('wp --quiet option update ionos_group_brand ionos');
       await admin.visitAdminPage('/');
 
       const body = await page.locator('body');

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/next-best-actions.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/next-best-actions.spec.js
@@ -15,8 +15,6 @@ test.describe(
         wp --quiet user meta update 1 ionos_essentials_welcome true
         # simulate extendify onboarding already done
         wp --quiet option update extendify_attempted_redirect_count 4
-        # simulate switch page decision
-        wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy
       `);
     });
 

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/security-options.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/security-options.spec.js
@@ -16,11 +16,9 @@ test.describe(
         # simulate extendify onboarding already done
         wp --quiet option update extendify_attempted_redirect_count 4
         
-        # simulate switch page decision
-        wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy
-        
         # test specific
-        wp --quiet option delete IONOS_SECURITY_FEATURE_OPTION`);
+        wp --quiet option delete IONOS_SECURITY_FEATURE_OPTION
+        `);
     });
 
     test('user can set option', async ({ admin, page }) => {

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/welcome.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/dashboard/tests/e2e/welcome.spec.js
@@ -8,11 +8,7 @@ test.describe(
   },
   () => {
     test.beforeAll(async () => {
-      execTestCLI(`
-        # simulate switch page decision
-        wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy
-        wp --quiet user meta delete 1 ionos_essentials_welcome
-        `);
+      execTestCLI(`wp --quiet user meta delete 1 ionos_essentials_welcome`);
     });
 
     test('test welcome banner has tenant title', async ({ admin, page }) => {

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/maintenance_mode/tests/e2e/maintenance.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/maintenance_mode/tests/e2e/maintenance.spec.js
@@ -15,8 +15,6 @@ test.describe(
         wp --quiet user meta update 1 ionos_essentials_welcome true
         # simulate extendify onboarding already done
         wp --quiet option update extendify_attempted_redirect_count 4
-        # simulate switch page decision
-        wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy
         # reset maintenance mode
         wp --quiet option delete ionos_essentials_maintenance_mode
       `);

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/migration/index.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/migration/index.php
@@ -151,7 +151,6 @@ function _install()
       // no break
     case version_compare($last_installed_version, '1.4.6', '<='):
       \update_option('ionos_wpscan_issues_sent_to_user', \get_transient('ionos_wpscan_issues_sent_to_user'), []);
-
   }
   \update_option(option: WP_OPTION_LAST_INSTALL_DATA, value: $current_install_data, autoload: true);
 }

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/index.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/index.php
@@ -6,15 +6,6 @@ use ionos\essentials\Tenant;
 
 defined('ABSPATH') || exit();
 
-const IONOS_ONBOARDING_OPTION    = 'IONOS_ESSENTIALS_ONBOARDING';
-const IONOS_ONBOARDING_QUERY_ARG = 'ionos_onboarding';
-
-if (isset($_GET[IONOS_ONBOARDING_QUERY_ARG])) {
-  \add_action('admin_init', function () {
-    \update_option(IONOS_ONBOARDING_OPTION, $_GET[IONOS_ONBOARDING_QUERY_ARG], true);
-  });
-}
-
 /**
  * Add onboarding menu page.
  */
@@ -37,26 +28,21 @@ if (isset($_GET[IONOS_ONBOARDING_QUERY_ARG])) {
 );
 
 /**
- * Redirects to extendify-pages are caught.
- * We send the user to the switch page or their configured dashboard
+ * Redirects to extendify-launch are caught.
+ * We send the user to the ai-switch-page
  */
 \add_filter(
   'wp_redirect',
   function ($location) {
     // extendify-launch always opens switch page
     if (\admin_url('admin.php?page=extendify-launch') === $location) {
-      // avoid redirect loops
-      update_option('extendify_attempted_redirect_count', 3);
       return \admin_url('admin.php?page=' . Tenant::get_slug() . '-onboarding');
     }
-    // other dashboards should redirect to our switch page, or the configured wp-admin dashboard
+    // wp-admin and extendify dashboard redirect to our dashboard OR the default wp-admin dashboard
     $redirects = ['wp-admin/', admin_url(), \admin_url('admin.php?page=extendify-assist')];
     if (in_array($location, $redirects)) {
-      if (! get_option(IONOS_ONBOARDING_OPTION)) {
-        return \admin_url('admin.php?page=' . Tenant::get_slug() . '-onboarding');
-      }
-      $default_to_ionos_dashboard = (\get_option('ionos_essentials_dashboard_mode', true));
-      return $default_to_ionos_dashboard ? \admin_url('admin.php?page=' . Tenant::get_slug()) : \admin_url();
+      $show_ionos_dashboard = (\get_option('ionos_essentials_dashboard_mode', true));
+      return $show_ionos_dashboard ? \admin_url('admin.php?page=' . Tenant::get_slug()) : \admin_url();
     }
     return $location;
   },
@@ -66,7 +52,7 @@ if (isset($_GET[IONOS_ONBOARDING_QUERY_ARG])) {
 
 \add_action(
   'load-toplevel_page_extendify-assist',
-  fn () => \wp_safe_redirect(\admin_url('admin.php?page=' . Tenant::get_slug())) && exit
+  fn () => \wp_safe_redirect(\admin_url('admin.php?page=' . Tenant::get_slug()))
 );
 
 \add_filter(

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/tests/e2e/switch-page.spec.js
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/tests/e2e/switch-page.spec.js
@@ -1,5 +1,4 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
-import { execTestCLI } from '../../../../../../../../playwright/wp-env';
 
 test.describe(
   'Switch page',
@@ -21,47 +20,6 @@ test.describe(
       await expect(page.getByRole('link', { name: 'Create manually' })).toBeVisible();
       // .toHaveLength(0) is best practice according to playwright docs
       await expect(errors).toHaveLength(0);
-    });
-
-    test.describe('onboarding redirect', () => {
-      test.beforeEach(async () => {
-        execTestCLI(`wp --quiet option delete IONOS_ESSENTIALS_ONBOARDING`);
-      });
-
-      test('wp-admin/ redirects to switch page when onboarding not done', async ({ admin, page }) => {
-        await admin.visitAdminPage('/');
-        await expect(page).toHaveURL(/page=.*-onboarding/);
-      });
-
-      test('IONOS dashboard redirects to switch page when onboarding not done', async ({ admin, page }) => {
-        await admin.visitAdminPage('/admin.php?page=ionos');
-        await expect(page).toHaveURL(/page=.*-onboarding/);
-      });
-
-      test('"Create manually" button includes ionos_onboarding=diy query arg', async ({ admin, page }) => {
-        await admin.visitAdminPage('/admin.php?page=ionos-onboarding');
-        const link = page.getByRole('link', { name: 'Create manually' });
-        await expect(link).toHaveAttribute('href', /ionos_onboarding=diy/);
-      });
-
-      test('"Continue with AI" button includes ionos_onboarding=ai query arg', async ({ admin, page }) => {
-        await admin.visitAdminPage('/admin.php?page=ionos-onboarding');
-        const link = page.locator('a[href*="extendify-launch"]');
-        await expect(link).toHaveAttribute('href', /ionos_onboarding=ai/);
-      });
-
-      test('clicking "Create manually" persists diy choice and lands on IONOS dashboard', async ({ admin, page }) => {
-        await admin.visitAdminPage('/admin.php?page=ionos-onboarding');
-        await page.getByRole('link', { name: 'Create manually' }).click();
-        await expect(page).toHaveURL(/page=ionos/);
-        await expect(page).not.toHaveURL(/page=.*-onboarding/);
-      });
-
-      test('after onboarding, wp-admin/ no longer redirects to switch page', async ({ admin, page }) => {
-        execTestCLI(`wp --quiet option update IONOS_ESSENTIALS_ONBOARDING diy`);
-        await admin.visitAdminPage('/');
-        await expect(page).not.toHaveURL(/page=.*-onboarding/);
-      });
     });
   }
 );

--- a/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/view.php
+++ b/packages/wp-plugin/ionos-essentials/ionos-essentials/inc/switch-page/view.php
@@ -76,7 +76,7 @@ if (file_exists($theme_file)) {
               'ionos-essentials'
             ); ?></p>
             <a href="<?php echo \esc_attr(
-              \admin_url('admin.php?page=extendify-launch&' . IONOS_ONBOARDING_QUERY_ARG . '=ai')
+              \admin_url('admin.php?page=extendify-launch')
             ); ?>" class="button button--primary"><?php \esc_html_e('Continue with AI', 'ionos-essentials'); ?></a>
           </div>
         </div>
@@ -92,7 +92,7 @@ if (file_exists($theme_file)) {
               'ionos-essentials'
             ); ?></p>
             <a href="<?php echo \esc_attr(
-              \admin_url('admin.php?page=' . Tenant::get_slug() . '&' . IONOS_ONBOARDING_QUERY_ARG . '=diy')
+              \admin_url('admin.php?page=' . Tenant::get_slug())
             ); ?>" class="button button--secondary"><?php \esc_html_e('Create manually', 'ionos-essentials'); ?></a>
           </div>
         </div>


### PR DESCRIPTION

This reverts commit 212e8c52c59399db1259d9ccd4a2381ca4ab2ce3, reversing changes made to f6a5c56f6c5e6efbcb8bd4c5977a530bbf3643d5.

## Description

switch page based on option needs a migration for existing users. The change showed it to every user on wp-admin login