### PR TITLE
feat: add GitHub Copilot review workflow for pull requests

### DIFF
--- a/.github/workflows/copilot-review.yaml
+++ b/.github/workflows/copilot-review.yaml
@@ -1,0 +1,26 @@
+#
+# triggers a GitHub Copilot code review when a pull request is moved from draft to ready for review
+#
+name: 'copilot-review'
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+
+jobs:
+  request-copilot-review:
+    name: Request Copilot review
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add Copilot as reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -f "reviewers[]=github-copilot[bot]"


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that automatically requests a GitHub Copilot code review whenever a pull request is switched from draft to ready for review. Previously this had to be done manually by the PR author.

## Checklist

- [x] Acceptance Criteria are fulfilled (or there is no ticket)

## manual testing

  1. Create a new branch and open a pull request as **draft**.
  2. Confirm the `copilot-review` workflow does **not** trigger (it only fires on `ready_for_review`, not `opened`).
  3. Click **"Ready for review"** to move the PR out of draft.
  4. Navigate to the **Actions** tab and verify the `copilot-review` workflow run appears and completes successfully.
  5. On the PR page, verify that **`github-copilot[bot]`** is listed under **Reviewers** within ~30 seconds.
  6. Confirm Copilot eventually posts a review comment on the PR.

  > **Note:** Step 6 requires GitHub Copilot for Pull Requests to be enabled for the `IONOS-WordPress` organisation. If the workflow run succeeds but no Copilot reviewer appears, check the Actions log for a 422 response — that indicates the feature is not yet enabled.