### PR TITLE
feat: add Claude Code to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -76,7 +76,11 @@ ENV XDEBUG_MODE off
 RUN curl https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" PNPM_VERSION="$PNPM_VERSION" SHELL="$(which bash)" bash -
 
 ENV PNPM_HOME /home/$USERNAME/.local/share/pnpm
-ENV PATH $PNPM_HOME:$PATH
-RUN pnpm env use --global $PNPM_NODEJS_VERSION
+ENV PATH $PNPM_HOME:$PNPM_HOME/bin:$PATH
+# pnpm-managed node only symlinks node/npm/pnpm themselves into $PNPM_HOME, not
+# npm's own bin dir, so global npm installs (e.g. the claude-code devcontainer
+# feature) land outside PATH unless npm's global prefix is pointed at $PNPM_HOME
+RUN pnpm env use --global $PNPM_NODEJS_VERSION \
+  && npm config set prefix "$PNPM_HOME" --location=global
 RUN pnpm config set store-dir home/$USERNAME/.pnpm-store
 RUN bash -c "pnpx playwright install-deps"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,6 +81,7 @@ ENV PATH $PNPM_HOME:$PNPM_HOME/bin:$PATH
 # npm's own bin dir, so global npm installs (e.g. the claude-code devcontainer
 # feature) land outside PATH unless npm's global prefix is pointed at $PNPM_HOME
 RUN pnpm env use --global $PNPM_NODEJS_VERSION \
-  && npm config set prefix "$PNPM_HOME" --location=global
+  && npm config set prefix "$PNPM_HOME" --location=global \
+  && mkdir -p "$HOME/.claude"
 RUN pnpm config set store-dir home/$USERNAME/.pnpm-store
 RUN bash -c "pnpx playwright install-deps"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
     "vscode": {
       "settings": {
         "workbench.colorCustomizations": {
-          // highlight title bar to make developer sensuible that he is in a devcontainer
+          // highlight title bar to make developer sensible that he is in a devcontainer
           "titleBar.activeBackground": "#002b44"
         },
         "claude-code.environmentVariables": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,14 +15,22 @@
       "installDockerBuildx": true,
       "version": "latest",
       "dockerDashComposeVersion": "latest"
-    }
+    },
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
   },
 
   // Dev container build failed: Legacy feature 'mounts' not supported. Please check https://containers.dev/features for replacements
   //
   // enable persisted bash completion :
   // https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history
-  "mounts": ["source=projectname-bashhistory,target=/commandhistory,type=volume"],
+  "mounts": [
+    "source=projectname-bashhistory,target=/commandhistory,type=volume",
+    "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume"
+  ],
+
+  "containerEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
+  },
 
   "customizations": {
     "vscode": {
@@ -30,7 +38,13 @@
         "workbench.colorCustomizations": {
           // highlight title bar to make developer sensuible that he is in a devcontainer
           "titleBar.activeBackground": "#002b44"
-        }
+        },
+        "claude-code.environmentVariables": [
+          {
+            "name": "ANTHROPIC_API_KEY",
+            "value": "${localEnv:ANTHROPIC_API_KEY}"
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
This feature automatically enables Claude Code in DevContainer environment. 

## Prerequisites

Host environment variables `ANTHROPIC_API_KEY` needs to be set. This variable will automatically be delegated into the DevContainer.

## Summary

- Add the `ghcr.io/anthropics/devcontainer-features/claude-code:1` devcontainer feature so Claude Code is available inside the dev container
- Persist Claude Code config/auth across rebuilds via a named volume (`claude-code-config-${devcontainerId}`) mounted at `/home/vscode/.claude`
- Forward `ANTHROPIC_API_KEY` from the host into the container (`containerEnv`) and into the VS Code Claude Code extension settings
- Fix `PATH`/npm global prefix in the Dockerfile so npm global installs (e.g. the claude-code feature) resolve on `PATH` — pnpm's managed Node install only symlinks `node`/`npm`/`pnpm` into `$PNPM_HOME`, not npm's own global bin dir, so `npm config set prefix "$PNPM_HOME"` is needed to keep future global installs discoverable

## Test plan
- [x] Rebuild the devcontainer and confirm it builds successfully
- [x] Confirm `pnpm`/`node`/`npm` still resolve correctly on `PATH`
- [x] Confirm the `claude` CLI is available and on `PATH` inside the container
- [x] Confirm the Claude Code VS Code extension picks up `ANTHROPIC_API_KEY` and authenticates
- [x] Rebuild the container again and confirm Claude Code config persists (via the mounted volume)
