### PR TITLE
fix(stretch-extra): fix invalid HTML/unicode breaking DeepL i18n auto-translation

### DIFF
--- a/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/marketplace/config.php
+++ b/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/marketplace/config.php
@@ -43,7 +43,7 @@ return [
     'beyond-seo' => [
       'info_url'          => 'https://wordpress.rankingcoach.com/update/archives/beyond-seo.json',
       'name'              => 'BeyondSEO',
-      'short_description' => __('BeyondSEO is a comprehensive WordPress SEO plugin designed to enhance Google search rankings and online visibility.<br><br>It provides advanced SEO analysis, content optimization, keyword research with competition metrics, automated meta tag management, AI-powered content suggestions, local SEO tools, and seamless integrations with external services. <br><br>The plugin features a robust onboarding system, multi-language support, and deep WordPress integration for effective online marketing and SEO management.', 'stretch-extra'),
+      'short_description' => __('BeyondSEO is a comprehensive WordPress SEO plugin designed to enhance Google search rankings and online visibility.<br /><br />It provides advanced SEO analysis, content optimization, keyword research with competition metrics, automated meta tag management, AI-powered content suggestions, local SEO tools, and seamless integrations with external services. <br /><br />The plugin features a robust onboarding system, multi-language support, and deep WordPress integration for effective online marketing and SEO management.', 'stretch-extra'),
       'version'           => 'latest',
       'author'            => 'BeyondSEO Team',
       'slug'              => 'beyond-seo',

--- a/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/plugin-block-list/plugin-block-list.php
+++ b/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/plugin-block-list/plugin-block-list.php
@@ -132,7 +132,7 @@ function block_disallowed_post_install($true, $hook_extra, $result)
   ');
 
   echo '<p class="zip-upload-text">' . esc_html__(
-    'Validating against blocked plugins...',
+    'Validating against blocked plugins…',
     'stretch-extra'
   ) . '</p>';
 

--- a/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/plugin-block-list/plugin-block-list.php
+++ b/packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/plugin-block-list/plugin-block-list.php
@@ -132,7 +132,7 @@ function block_disallowed_post_install($true, $hook_extra, $result)
   ');
 
   echo '<p class="zip-upload-text">' . esc_html__(
-    'Validating against blocked plugins…',
+    'Validating against blocked plugins...',
     'stretch-extra'
   ) . '</p>';
 

--- a/packages/wp-mu-plugin/stretch-extra/stretch-extra/languages/stretch-extra.pot
+++ b/packages/wp-mu-plugin/stretch-extra/stretch-extra/languages/stretch-extra.pot
@@ -52,7 +52,7 @@ msgid "Extension for WooCommerce providing features for legal compliance when yo
 msgstr ""
 
 #: stretch-extra/inc/marketplace/config.php
-msgid "BeyondSEO is a comprehensive WordPress SEO plugin designed to enhance Google search rankings and online visibility.<br><br>It provides advanced SEO analysis, content optimization, keyword research with competition metrics, automated meta tag management, AI-powered content suggestions, local SEO tools, and seamless integrations with external services. <br><br>The plugin features a robust onboarding system, multi-language support, and deep WordPress integration for effective online marketing and SEO management."
+msgid "BeyondSEO is a comprehensive WordPress SEO plugin designed to enhance Google search rankings and online visibility.<br /><br />It provides advanced SEO analysis, content optimization, keyword research with competition metrics, automated meta tag management, AI-powered content suggestions, local SEO tools, and seamless integrations with external services. <br /><br />The plugin features a robust onboarding system, multi-language support, and deep WordPress integration for effective online marketing and SEO management."
 msgstr ""
 
 #: stretch-extra/inc/marketplace/config.php


### PR DESCRIPTION
## Summary

`pnpm lint-fix:i18n` failed for the `stretch-extra` plugin with:

```
ERROR: Bad request, message: Tag handling parsing failed, please check input.
'undefined entity: line 1, column 41' (at Line: 1, Column: 34) on /composer/vendor/deeplcom/deepl-php/src/Translator.php at 779
```

Two source strings contained content that broke DeepL's XML tag-handling parser:

- `inc/marketplace/config.php`: the BeyondSEO marketplace description used unclosed `<br><br>` tags, which are not valid XML. Changed to self-closing `<br /><br />`, matching the convention already used elsewhere (e.g. `ionos-essentials`).
- `inc/plugin-block-list/plugin-block-list.php`: the "Validating against blocked plugins…" string used the Unicode ellipsis character (`…`). Our vendored translation tool (`om/potrans`'s `DeepLTranslator`) runs strings through PHP's `htmlentities()` before sending them to DeepL, which converts `…` into the named HTML entity `&hellip;`. DeepL's XML parser only understands the 5 standard XML entities (`&amp; &lt; &gt; &apos; &quot;`), so `&hellip;` was rejected as an "undefined entity". Replaced with a literal `...`.

Regenerated the `.pot`/`.po` files for `stretch-extra` and re-ran the DeepL auto-translation — all 8 locales now translate successfully.

## Changes

- `packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/marketplace/config.php`: `<br><br>` → `<br /><br />`
- `packages/wp-mu-plugin/stretch-extra/stretch-extra/inc/plugin-block-list/plugin-block-list.php`: `…` → `...`
- Regenerated `packages/wp-mu-plugin/stretch-extra/stretch-extra/languages/*.{pot,po,mo,json,php}`

## Test plan

- [x] Ran `pnpm build --use wp-plugin:i18n --filter @ionos-wordpress/stretch-extra` to regenerate pot/po with the fixed source strings
- [x] Ran `pnpm lint-fix:i18n` — all 8 `stretch-extra` locales (de_DE, en_US, es_ES, es_MX, fr_FR, it_IT, nl_NL, sv_SE) translate successfully via DeepL with no errors
- [x] Re-ran the build a second time to confirm the generated files are stable (no further drift)
