### PR TITLE
chore(scripts): clean up composer cache in destroy script

### DIFF
--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -22,5 +22,6 @@ fi
 rm -rf "$WP_ENV_HOME"
 
 # clean up composer cache
-rm -rf ~/.cache/composer
+COMPOSER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME:?}/.cache}/composer"
+rm -rf -- "$COMPOSER_CACHE_DIR"
 

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -20,3 +20,7 @@ fi
 
 # ensure wp-env-home is also removed, even in case wp-env was unable to remove it
 rm -rf "$WP_ENV_HOME"
+
+# clean up composer cache
+rm -rf ~/.cache/composer
+


### PR DESCRIPTION
Remove ~/.cache/composer when running the destroy script to fully reset the local environment and free disk space.

## Description

DELETE if branch name + PR title are self-explanatory

## Checklist

- [x] Acceptance Criteria are fulfilled (or there is no ticket)
- [x] tests added if necessary
- [x] docs added if necessary

## Screenshots / Recordings

_If the ui was changed by PR please provide a screenshot_

## manual testing

- [x] done / trivial change (docs, ...)
- [ ] requested
      _Please replace this line with instructions on how to test your changes_

## Reviewer checklist

- [ ] if requested manual testing done
- [ ] sufficient tests
- [ ] sufficient docs
- [ ] general Code Review
